### PR TITLE
Add ability to repeat the currently playing song (#76)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.22'
+version = '0.9.23'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -57,6 +57,9 @@ public class Constants {
     // Purchase Types
     public static final String RANK_BACKGROUND_PURCHASE_TYPE = "rank-background";
 
+    // Audio Metadata
+    public static final String AUDIO_HAS_SENT_NOW_PLAYING_METADATA = "has-sent-now-playing";
+
     // Command source link
     public static final String SOURCE_URI = "https://github.com/avaire/avaire/tree/master/src/main/java/com/avairebot/commands/%s/%s.java";
 }

--- a/src/main/java/com/avairebot/audio/AudioTrackContainer.java
+++ b/src/main/java/com/avairebot/audio/AudioTrackContainer.java
@@ -22,20 +22,28 @@
 package com.avairebot.audio;
 
 import com.avairebot.contracts.debug.Evalable;
+import com.avairebot.contracts.metadata.HasMetadata;
 import com.avairebot.utilities.NumberUtil;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import lavalink.client.player.IPlayer;
 import net.dv8tion.jda.core.entities.User;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class AudioTrackContainer extends Evalable {
+public class AudioTrackContainer extends Evalable implements HasMetadata<String, Object> {
 
     private final AudioTrack audioTrack;
     private final User requester;
     private final List<Long> skips;
     private int playedTime;
+
+    @Nullable
+    private HashMap<String, Object> metadata;
 
     public AudioTrackContainer(AudioTrack audioTrack, User requester) {
         this.audioTrack = audioTrack;
@@ -79,5 +87,57 @@ public class AudioTrackContainer extends Evalable {
         }
 
         return NumberUtil.formatTime(getAudioTrack().getDuration() - player.getTrackPosition());
+    }
+
+    @Override
+    public void setMetadata(@Nonnull String key, @Nullable Object value) {
+        if (metadata == null) {
+            metadata = new HashMap<>();
+        }
+
+        if (value == null) {
+            metadata.remove(key);
+        } else {
+            metadata.put(key, value);
+        }
+    }
+
+    @Override
+    public void removeMetadata(@Nonnull String key) {
+        if (metadata != null) {
+            metadata.remove(key);
+        }
+    }
+
+    @Nullable
+    @Override
+    public HashMap<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    @Nullable
+    @Override
+    public Object getMetadataFromKey(@Nonnull String key) {
+        if (metadata == null) {
+            return null;
+        }
+        return metadata.getOrDefault(key, null);
+    }
+
+    @Override
+    public boolean hasMetadataKey(@Nonnull String key) {
+        return metadata != null && metadata.containsKey(key);
+    }
+
+    public AudioTrackContainer makeClone() {
+        AudioTrackContainer container = new AudioTrackContainer(audioTrack.makeClone(), requester);
+
+        if (metadata != null) {
+            for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+                container.setMetadata(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return container;
     }
 }

--- a/src/main/java/com/avairebot/audio/GuildMusicManager.java
+++ b/src/main/java/com/avairebot/audio/GuildMusicManager.java
@@ -22,6 +22,7 @@
 package com.avairebot.audio;
 
 import com.avairebot.AvaIre;
+import com.avairebot.Constants;
 import com.avairebot.commands.CommandMessage;
 import com.avairebot.contracts.commands.Command;
 import com.avairebot.contracts.debug.Evalable;
@@ -48,9 +49,9 @@ public class GuildMusicManager extends Evalable {
 
     private boolean hasSetVolume;
     private boolean hasPlayedSongBefore;
-    private boolean repeatQueue;
     private int defaultVolume;
     private CommandMessage lastActiveMessage = null;
+    private RepeatState repeatState = RepeatState.LOOPOFF;
 
     public GuildMusicManager(AvaIre avaire, Guild guild) {
         this.avaire = avaire;
@@ -100,12 +101,16 @@ public class GuildMusicManager extends Evalable {
         return scheduler;
     }
 
-    public boolean isRepeatQueue() {
-        return repeatQueue;
+    public RepeatState getRepeatState() {
+        return repeatState;
     }
 
-    public void setRepeatQueue(boolean repeatQueue) {
-        this.repeatQueue = repeatQueue;
+    public void setRepeatState(RepeatState repeatState) {
+        if (repeatState.equals(RepeatState.SINGLE) && scheduler.getAudioTrackContainer() != null) {
+            scheduler.getAudioTrackContainer().removeMetadata(Constants.AUDIO_HAS_SENT_NOW_PLAYING_METADATA);
+            scheduler.getQueue().forEach(container -> container.removeMetadata(Constants.AUDIO_HAS_SENT_NOW_PLAYING_METADATA));
+        }
+        this.repeatState = repeatState;
     }
 
     public boolean hasPlayedSongBefore() {
@@ -157,5 +162,14 @@ public class GuildMusicManager extends Evalable {
 
     AudioPlayerSendHandler getSendHandler() {
         return new AudioPlayerSendHandler((LavaplayerPlayerWrapper) player);
+    }
+
+    public enum RepeatState {
+
+        LOOPOFF, SINGLE, ALL;
+
+        public String getName() {
+            return super.toString().toLowerCase();
+        }
     }
 }

--- a/src/main/java/com/avairebot/audio/TrackScheduler.java
+++ b/src/main/java/com/avairebot/audio/TrackScheduler.java
@@ -230,17 +230,17 @@ public class TrackScheduler extends AudioEventWrapper {
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         if (endReason.mayStartNext) {
-            if (manager.isRepeatQueue()) {
-                if (audioTrackContainer == null) {
-                    // This should never be null since the container is set when we queue a
-                    // track, and this even should only be fired when an track has ended.
-                    throw new IllegalStateException("Music track has ended while the audio track container is NULL");
-                }
-                queue.offer(new AudioTrackContainer(track.makeClone(), audioTrackContainer.getRequester()));
+            if (manager.getRepeatState().equals(GuildMusicManager.RepeatState.SINGLE)) {
+                queue.offerFirst(audioTrackContainer.makeClone());
+            } else if (manager.getRepeatState().equals(GuildMusicManager.RepeatState.ALL)) {
+                queue.offer(audioTrackContainer.makeClone());
             }
             nextTrack();
         } else if (endReason.equals(AudioTrackEndReason.FINISHED) && queue.isEmpty()) {
-            if (manager.getLastActiveMessage() != null) {
+            if (manager.getRepeatState().equals(GuildMusicManager.RepeatState.SINGLE)) {
+                queue.offerFirst(audioTrackContainer.makeClone());
+                nextTrack();
+            } else if (manager.getLastActiveMessage() != null) {
                 service.submit(() -> handleEndOfQueueWithLastActiveMessage(true));
             }
         }
@@ -268,6 +268,7 @@ public class TrackScheduler extends AudioEventWrapper {
         LavalinkManager.LavalinkManagerHolder.lavalink.closeConnection(context.getGuild());
 
         GuildMusicManager manager = AudioHandler.getDefaultAudioHandler().getGuildAudioPlayer(context.getGuild());
+        manager.setRepeatState(GuildMusicManager.RepeatState.LOOPOFF);
         manager.getPlayer().removeListener(this);
 
         if (LavalinkManager.LavalinkManagerHolder.lavalink.isEnabled()) {

--- a/src/main/java/com/avairebot/commands/music/RemoveSongFromQueueCommand.java
+++ b/src/main/java/com/avairebot/commands/music/RemoveSongFromQueueCommand.java
@@ -71,7 +71,7 @@ public class RemoveSongFromQueueCommand extends Command {
 
     @Override
     public List<String> getTriggers() {
-        return Arrays.asList("removesong", "songremove");
+        return Arrays.asList("removesong", "songremove", "removesongs");
     }
 
     @Override

--- a/src/main/java/com/avairebot/commands/music/StopCommand.java
+++ b/src/main/java/com/avairebot/commands/music/StopCommand.java
@@ -96,6 +96,7 @@ public class StopCommand extends Command {
         String guildId = context.getGuild().getId();
         int size = musicManager.getScheduler().getQueue().size();
 
+        musicManager.setRepeatState(GuildMusicManager.RepeatState.LOOPOFF);
         musicManager.getPlayer().stopTrack();
         musicManager.getScheduler().getQueue().clear();
 

--- a/src/main/java/com/avairebot/contracts/metadata/HasMetadata.java
+++ b/src/main/java/com/avairebot/contracts/metadata/HasMetadata.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.contracts.metadata;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+
+public interface HasMetadata<T, V> {
+
+    /**
+     * Sets the metadata key for the object, setting the key to the given value,
+     * if {@code NULL} is given, the key is instead removed from the metadata.
+     *
+     * @param key   The key that the value should be stored under.
+     * @param value The value that should be stored.
+     */
+    void setMetadata(@Nonnull String key, @Nullable Object value);
+
+    /**
+     * Removes the given key from the metadata if it exists.
+     *
+     * @param key The key that should be removed from the metadata.
+     */
+    void removeMetadata(@Nonnull String key);
+
+    /**
+     * Returns the full metadata object, or {@code NULL} if
+     * nothing has been saved to the metadata object yet.
+     *
+     * @return Possibly-null, the full metadata object.
+     */
+    @Nullable
+    HashMap<T, V> getMetadata();
+
+    /**
+     * Gets the value of the given key from the metadata object,
+     * if the key doesn't exist in the metadata object,
+     * {@code NULL} will be returned instead.
+     *
+     * @param key The key that should have its value returned.
+     * @return Possibly-null, the value of the given key.
+     */
+    @Nullable
+    V getMetadataFromKey(@Nonnull String key);
+
+    /**
+     * Checks if the given key exists in the metadata object.
+     *
+     * @param key The key that should be checked exists.
+     * @return {@code True} if the key exists, {@code False} otherwise.
+     */
+    boolean hasMetadataKey(@Nonnull String key);
+}

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -555,10 +555,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: 'Der er ikke noget at gentage, start noget musik først med `{0}play`'
-        success: 'Musikkøens looping er blevet `:status`.'
-        enabled: 'aktiveret'
-        disabled: 'deaktiveret'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Intet at genoptage, start noget musik først med `{0}play`'

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -557,10 +557,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: "Nicht's zum Wiederholen vorhanden. Anfragen von Musik ist vorausgesetzt. Tue dies bitte zuerst mit folgendem Befehl: `{0}play`"
-        success: 'Das Wiederholen von der Musik-Warteschlange ist nun `:status`.'
-        enabled: 'EINGESCHALTET'
-        disabled: 'AUSGESCHALTET'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: "Nicht's zum Fortsetzen vorhanden. Anfragen von Musik ist vorausgesetzt. Tue dies bitte zuerst mit folgendem Befehl: `{0}play`"

--- a/src/main/resources/langs/en_PT.yml
+++ b/src/main/resources/langs/en_PT.yml
@@ -556,10 +556,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: "Thar be naught t' repeat, request shanties first wit' `{0}play`"
-        success: "Music queue loopin' has been turned `:status`."
-        enabled: 'ON'
-        disabled: 'OFF'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: "Nothin' t' resume, request chanties first wit' `{0}play`"

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -458,17 +458,17 @@ music:
         success: 'I have removed **:queueSize** songs from the queue, the queue is now empty!'
 
     DJLevelCommand:
-            title: "Current DJ Level: {0}"
-            footer: "Use \"{0} types\" to see a full list of the available DJ level types."
-            types:
-                title: "DJ Level Types"
-                footer: "Use \"{0} <type>\" to change the DJ Level to the given type for the server."
-            invalidType: "`{0}` is not a valid `DJ Level` type, please use one of the following:\n`{1}`"
-            changedTo: "The `DJ Level` status has changed to **:type**.\n:info"
-            information:
-                all: "Anyone can run any music commands, even without the `DJ` role."
-                none: "No one can run any music commands without the `DJ` role."
-                normal: "Preventing people from using commands like playlists, volume control, and force skip without the `DJ` role, but still allowing people to use the play command without the role."
+        title: "Current DJ Level: {0}"
+        footer: "Use \"{0} types\" to see a full list of the available DJ level types."
+        types:
+            title: "DJ Level Types"
+            footer: "Use \"{0} <type>\" to change the DJ Level to the given type for the server."
+        invalidType: "`{0}` is not a valid `DJ Level` type, please use one of the following:\n`{1}`"
+        changedTo: "The `DJ Level` status has changed to **:type**.\n:info"
+        information:
+            all: "Anyone can run any music commands, even without the `DJ` role."
+            none: "No one can run any music commands without the `DJ` role."
+            normal: "Preventing people from using commands like playlists, volume control, and force skip without the `DJ` role, but still allowing people to use the play command without the role."
 
     MoveHereCommand:
         error: 'Not connected to voice, request music first with `{0}play`'
@@ -556,9 +556,17 @@ music:
 
     RepeatMusicQueueCommand:
         error: 'There is nothing to repeat, request music first with `{0}play`'
-        success: 'Music queue looping has been turned `:status`.'
-        enabled: 'ON'
-        disabled: 'OFF'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Nothing to resume, request music first with `{0}play`'
@@ -808,8 +816,8 @@ utility:
         timeFormat: 'HH:mm:ss z'
 
     UserAvatarCommand:
-            noUserFound: "I found no users with the name or ID of `{0}`"
-            title: "{0}#{1}'s Avatar"
+        noUserFound: "I found no users with the name or ID of `{0}`"
+        title: "{0}#{1}'s Avatar"
 
     UserIdCommand:
         message: ':id: of the user **:target** is `:targetid`'

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -556,10 +556,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: 'No hay nada que repetir, pide música primero con `{0}play`'
-        success: 'El modo búcle de la música se ha establecido en `:status`.'
-        enabled: 'SÍ'
-        disabled: 'NO'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'No hay nada que reanudar, pide música primero con `{0}play`'

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -556,10 +556,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: "Il n'y a rien à répéter, demande un musique d'abord avec `{0}play`"
-        success: "La lecture en boucle de la file d'attente musicale est maintenant sur le status `:status`."
-        enabled: "ON"
-        disabled: "OFF"
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: "Rien à reprendre, demande une musique d'abord avec `{0}play`"

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -562,10 +562,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: 'Semmi sincs amit ismételni lehetne, előbb kérj zenét a `{0}play`-vel'
-        success: 'A zene ismétlés `:status` lett kapcsolva.'
-        enabled: 'BE'
-        disabled: 'KI'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Nincs semmi amit folytatni lehetne, előbb kérj zenét a `{0}play`-vel'

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -555,10 +555,18 @@ music:
         successMultipleNote: "\nE altri **{0}** brani sono stati rimossi dalla coda."
 
     RepeatMusicQueueCommand:
-        error: 'Nulla da ripetere, richiedi prima musica con `{0}play`'
-        success: 'La ripetizione della coda musicale è stata impostata su `:status`.'
-        enabled: 'ON'
-        disabled: 'OFF'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Nulla da riprendere, richiedi prima musica con `{0}play`'

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -555,10 +555,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: 'Det er ingenting og gjennta, etterspør musikk først med `{0}play`'
-        success: 'Musikk kø looping er blitt skrudd `:status`.'
-        enabled: 'PÅ'
-        disabled: 'AV'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Ingenting og gjennoppta, etterspør musikk først med `{0}play`'

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -556,10 +556,18 @@ music:
         successMultipleNote: "\nAnd **{0}** more songs were removed from the queue."
 
     RepeatMusicQueueCommand:
-        error: 'Нечего повторять, сначала попросите музыку `{0}play`'
-        success: 'Повтор музыкальной очереди завершен `:status`'
-        enabled: 'ВКЛЮЧЕН'
-        disabled: 'ОТКЛЮЧЕН'
+        error: 'There is nothing to repeat, request music first with `{0}play`'
+        title: 'Current repeat mode: {0}'
+        message: "The music player repeat status have been successfully changed to **:state**, this means:\n\n:note"
+        footer: 'Use "{0} <repeat-mode>" to set the repeat mode.'
+        states:
+            single: 'One'
+            all: 'All'
+            loopoff: 'Off'
+        notes:
+            single: 'The music player will repeat the song that is currently playing without going to the next song in the queue.\n**Note:** This also mutes "Now Playing" messages so the chat is not spammed with the same song over and over again.'
+            all: 'The music player will repeat every song in the queue, after a song finishes playing it will be re-added to the end of the queue automatically.'
+            loopoff: 'The music player will not loop, when a song finishes playing it will get removed from the queue and the next track will begin playing.'
 
     ResumeCommand:
         error: 'Нечего возобновлять, сначала попросите музыку `{0}play`'


### PR DESCRIPTION
This PR closes #46 and adds the ability to repeat the currently playing song on loop. In order to make this work, I had to rewrite RepeatMusicQueueCommand and change the queue to use a double ended queue. There's still some testing that needs to be done to make sure everything works and looks ok. I would also appreciate it if you would look over everything else so nothing is accidentally broken by this change.

TODO:

- [x] Add basic functionality
- [x] Add functionality to display current repeat mode
- [x] Rewrite usage instructions
- [x] Make better success info
- [x] Fix duplicate now playing messages
- [x] Test repeatsongs command in different scenarios
- [x] Make sure the change to deque doesn't break other commands and methods