### PR TITLE
Force all calendar instances to use the English locale

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.53'
+version = '0.9.54'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.54'
+version = '0.9.55'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/time/Carbon.java
+++ b/src/main/java/com/avairebot/time/Carbon.java
@@ -493,7 +493,7 @@ public final class Carbon {
      *                                  string format is invalid.
      */
     public static Carbon createFromFormat(String format, String time) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date date = sdf.parse(time);
 
@@ -514,7 +514,7 @@ public final class Carbon {
      *                                  string format is invalid.
      */
     public static Carbon createFromFormat(String format, String time, String timezone) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date date = sdf.parse(time);
 
@@ -535,7 +535,7 @@ public final class Carbon {
      *                                  string format is invalid.
      */
     public static Carbon createFromFormat(String format, String time, TimeZone timezone) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         Date date = sdf.parse(time);
 
@@ -2115,7 +2115,7 @@ public final class Carbon {
      * @return the formatted datetime string
      */
     public String format(String format) {
-        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.ENGLISH);
 
         if (timezone != null) {
             sdf.setTimeZone(timezone);

--- a/src/main/java/com/avairebot/time/Carbon.java
+++ b/src/main/java/com/avairebot/time/Carbon.java
@@ -58,7 +58,7 @@ public final class Carbon {
      * this is the same as the {@link Carbon#now() static now()} method.
      */
     public Carbon() {
-        this.time = Calendar.getInstance();
+        this.time = Calendar.getInstance(Locale.ENGLISH);
 
         this.WEEK_START_AT = GLOBAL_WEEK_START_AT;
         this.WEEK_END_AT = GLOBAL_WEEK_END_AT;
@@ -66,7 +66,7 @@ public final class Carbon {
         this.timezone = time.getTimeZone();
 
         this.time.setFirstDayOfWeek(WEEK_START_AT.getId());
-        this.time.setTime(Calendar.getInstance().getTime());
+        this.time.setTime(Calendar.getInstance(Locale.ENGLISH).getTime());
     }
 
     /**
@@ -80,7 +80,7 @@ public final class Carbon {
      * @see java.text.SimpleDateFormat
      */
     public Carbon(String time) throws InvalidFormatException {
-        this.time = Calendar.getInstance();
+        this.time = Calendar.getInstance(Locale.ENGLISH);
 
         this.WEEK_START_AT = GLOBAL_WEEK_START_AT;
         this.WEEK_END_AT = GLOBAL_WEEK_END_AT;
@@ -113,7 +113,7 @@ public final class Carbon {
      * @see java.text.SimpleDateFormat
      */
     public Carbon(String time, String timezone) throws InvalidFormatException {
-        this.time = Calendar.getInstance();
+        this.time = Calendar.getInstance(Locale.ENGLISH);
 
         this.WEEK_START_AT = GLOBAL_WEEK_START_AT;
         this.WEEK_END_AT = GLOBAL_WEEK_END_AT;
@@ -140,7 +140,7 @@ public final class Carbon {
      * @param instance the carbon instance to copy
      */
     public Carbon(Carbon instance) {
-        this.time = Calendar.getInstance();
+        this.time = Calendar.getInstance(Locale.ENGLISH);
 
         this.WEEK_START_AT = instance.WEEK_START_AT;
         this.WEEK_END_AT = instance.WEEK_END_AT;
@@ -158,7 +158,7 @@ public final class Carbon {
      * @param date The date to use to create the carbon instance
      */
     private Carbon(Date date) {
-        this.time = Calendar.getInstance();
+        this.time = Calendar.getInstance(Locale.ENGLISH);
 
         this.WEEK_START_AT = GLOBAL_WEEK_START_AT;
         this.WEEK_END_AT = GLOBAL_WEEK_END_AT;
@@ -759,16 +759,6 @@ public final class Carbon {
 
     /**
      * Sets the month to the carbon instance.
-     *
-     * @param month the month to set
-     * @return the Carbon instance
-     */
-    public Carbon setMonth(Month month) {
-        return set(Calendar.MONTH, month.getId());
-    }
-
-    /**
-     * Sets the month to the carbon instance.
      * <p>
      * This is a calendar-specific value. The first month of the year in the
      * Gregorian and Julian calendars is <code>JANUARY</code> which is 0;
@@ -792,6 +782,16 @@ public final class Carbon {
      */
     public Carbon setMonth(int month) {
         return set(Calendar.MONTH, month - 1);
+    }
+
+    /**
+     * Sets the month to the carbon instance.
+     *
+     * @param month the month to set
+     * @return the Carbon instance
+     */
+    public Carbon setMonth(Month month) {
+        return set(Calendar.MONTH, month.getId());
     }
 
     /**
@@ -1481,7 +1481,7 @@ public final class Carbon {
      * or (2) <code>FALSE</code> if it's set to the present or future.
      */
     public boolean isPast() {
-        return Calendar.getInstance().getTimeInMillis() > time.getTimeInMillis();
+        return Calendar.getInstance(Locale.ENGLISH).getTimeInMillis() > time.getTimeInMillis();
     }
 
     /**

--- a/src/main/java/com/avairebot/time/Formats.java
+++ b/src/main/java/com/avairebot/time/Formats.java
@@ -24,6 +24,7 @@ package com.avairebot.time;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public enum Formats {
 
@@ -115,7 +116,7 @@ public enum Formats {
      * @return the {@link java.text.SimpleDateFormat} format what was created.
      */
     public SimpleDateFormat make() {
-        return new SimpleDateFormat(string);
+        return new SimpleDateFormat(string, Locale.ENGLISH);
     }
 
     /**

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -51,17 +51,17 @@ administration:
     AdministrateExperienceCommand:
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "Modellen `Artificial Intelligence` er blivet **:status** for :channel kanalen."

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -51,17 +51,17 @@ administration:
     AdministrateExperienceCommand:
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "Der `Künstliche Intelligenz` Modul wurde **:status** für folgenden Channel: :channel"

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -50,17 +50,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "The `Artificial Intelligence` module has been **:status** for the :channel channel."

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -51,17 +51,17 @@ administration:
     AdministrateExperienceCommand:
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "The `Artificial Intelligence` module has been **:status** for the :channel channel."

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -58,17 +58,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "Le module Artificial Intelligence` a été **:status** pour le :channel channel."

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -12,49 +12,41 @@ errors:
     errorOccurredWhileLoading: "Une erreur est survenue lors du chargement de {0}, réessayer, si le problème persiste reportez le à l'un de mes développeurs sur le [serveur de support AvaIre](https://discord.gg/gt2FWER)."
 
 levelupMessages:
-    - "GG :user, tu as atteinds le niveau **Level :level**"
-    - "Eyy :user, tu viens d'augmenter de niveau! Tu es maintenant niveau **Level :level**"
-    - "🌟 Tu as atteinds le niveau **Level :level** :user! Félicitations 🌟"
-    - "Tu es en 🔥 :user, vous venez d'atteindre le niveau **Level :level**"
-    - "Félicitations :user 🎉 Tu viens d'augmenter de niveau! Tu es maintenant niveau **Level :level**"
+    - "GG :user, tu as atteint le **Niveau :level**"
+    - "Hey :user, tu viens de monter en niveau! Tu es maintenant **Niveau :level**"
+    - "🌟 Tu as atteint le **Niveau :level** :user! Félicitations 🌟"
+    - "Tu es en 🔥 :user, tu viens d'atteindre le **Niveau :level**"
+    - "Félicitations :user 🎉 Tu viens de monter en niveau! Tu es maintenant **Niveau :level**"
 
 levelupRoleMessages:
-    - "GG :user, tu as atteinds le niveau **Level :level**, tu as maintenant le rôle **:role** role"
-    - "Eyy :user, tu as augmenté de niveau! Tu es maintenant niveau **Level :level**, tu as le rôle **:role**, tu l'as mérité."
-    - "Félicitations :user 🎉  Tu as augmenté de niveau! Tu es maintenant niveau **Level :level**, tu as aussi gagner toi même le rôle **:role** role"
+    - "GG :user, tu as atteint le **Niveau :level**, tu as maintenant le rôle **:role**"
+    - "Eyy :user, tu viens de monter en niveau! Tu es maintenant **Niveau :level**, tu as le rôle **:role**, tu l'as mérité."
+    - "Félicitations :user 🎉  Tu viens de monter en niveau! Tu es maintenant **Niveau :level**, tu as aussi gagné le rôle **:role**"
 
 administration:
     common:
         invalidRole: ":user Rôle invalide, Je ne trouve pas de rôle appelé :role"
 
     channelModule:
-        invalidColorGiven: "Couleur donnée invalide, la couleur doit être une valeur valide HEX.\nTu peux essayer le [random color picker](https://www.webpagefx.com/web-design/random-color-picker/)"
-        message: "Le :type message module a été réglé sur:\n\n```:message```\n\n Tu peux tester le message en réutilisant la commande et mentionner un utilisateur. \n:command <user>"
+        invalidColorGiven: "Couleur invalide, la couleur doit être une valeur HEX valide.\nTu peux essayer ce [sélecteur de couleur aléatoire](https://www.webpagefx.com/web-design/random-color-picker/)"
+        message: "Le module message `:type` a été défini avec:\n\n```:message```\n\nTu peux tester le message en réutilisant la commande et mentionner un utilisateur.\n`:command <user>`"
 
     AddLevelRoleCommand:
-        noSlotsLeft: "Le serveur n'as plus de slots de rôle de niveaux, tu peux supprimer les rôles de niveau existant pour libérer des slots."
-        invalidLevel: "Le niveau demandé n'est pas valide, il doit être un nombre positif."
-        alreadyLevelRole: ":user The rôle :role est déja un rôle de niveau, tu ne peux pas utiliser le même rôle deux."
-        alreadyARoleAtLevel: "Il y a déja un rôle assigné au niveau :level, seulement un rôle peut être assigner à un niveau."
-        success: "Le rôle :role a été ajouté à la liste.\nLe server a :slots slots encore disponible."
+        noSlotsLeft: "Le serveur n'as plus d'emplacements pour les rôles de niveaux, tu peux supprimer les rôles de niveau existant pour libérer des emplacements."
+        invalidLevel: "Le niveau demandé est invalide, il doit être un nombre positif."
+        alreadyLevelRole: ":user le **rôle :role** est déja un rôle de niveau, tu ne peux pas utiliser deux fois le même rôle."
+        alreadyARoleAtLevel: "Il existe déja un rôle assigné au niveau **:level**, un seul rôle peut être assigner à un niveau."
+        success: "Le rôle **:role** a été ajouté à la liste des rôles de montée en niveau.\nLe server a encore `:slots` emplacements disponible."
 
     AddReactionRoleCommand:
-        emoteDoestBelongToServer: "L'émote n'appartient pas à ce serveur, tu peux utiliser seulement les emotes de ce serveur comme emotes de réaction."
-        messageHasNoSlots: "Le message n'a plus de slots de rôle de réaction disponibles, vous pouvez supprimer les rôles de réaction existants pour libérer des slots, ou supprimer les messages de rôle de réaction pour ajouter le rôle à un nouveau message."
-        serverHasNoSlots: "Tu ne peux pas créer de nouveaux messages de rôle de réaction, le serveur n'a plus d'emplacements de messages de réaction, tu peux supprimer des messages de rôle de réaction existants pour libérer des emplacements, ou ajouter ton rôle de réaction à un message de réaction s'il y a des emplacements disponibles sur le message pour plusieurs rôles."
-        success: "Le rôle :rôle a été enregistré comme rôle de réaction pour le :emote emote.\nLe message n'a `:roleSlots` plus d'emplacements de rôle de réaction disponibles pour le message, et `:messageSlots' des emplacements réaction-message disponible."
+        emoteDoestBelongToServer: "L'émote n'appartient pas à ce serveur, tu peux seulement utiliser les émotes de ce serveur pour réagir."
+        messageHasNoSlots: "Ce message n'a plus d'emplacement disponible pour les réactions de rôle. Tu peux supprimer les réactions de rôle existantes pour libérer des emplacements, ou supprimer les messages associé au rôle de réaction pour y ajouter un nouveau message."
+        serverHasNoSlots: "Impossible de créer de nouveaux messages pour les rôles de réaction, le serveur n'a plus d'emplacement disponible pour les messages de réaction. Tu peux supprimer certains de ces messages pour libérer des emplacements, ou ajouter ton rôle de réaction à un autre message de réaction qui a des emplacements disponibles pour des rôles."
+        success: "Le rôle :role a été enregistré en tant que rôle de réaction pour l'émote :emote.\nLe message a encore `:roleSlots` emplacements de role de réaction disponibles et `:messageSlots` emplacements de réaction disponibles."
 
     AddSelfAssignableRoleCommand:
         noSlotsLeft: "Le serveur n'a plus d'emplacements de rôle auto-assignables, tu peux supprimer les rôles auto-assignables existants pour libérer des emplacements."
-        success: "Le rôle **:role** a été ajouté à la liste des rôles auto-assignables. Le serveur a `:slots' plus de slots de rôles auto-assignables disponibles."
-        emoteDoestBelongToServer: "The emote does not belong to this server, you can only use emotes from this server as reaction emotes."
-        messageHasNoSlots: "The message doesn't have anymore reaction role slots available, you can remove existing reaction-roles to free up slots, or delete reaction role messages to add the role to a new reaction role message."
-        serverHasNoSlots: "Can't create new reaction role messages, the server doesn't have anymore reaction messages slots, you can deleting existing reaction role messages to free up slots, or add your reaction role to a reaction message if there are available slots on the message for more roles."
-        success: "The :role role has been registered as an reaction role for the :emote emote.\nThe message has `:roleSlots` more reaction-role slots available for the message, and `:messageSlots` reaction-message slots available."
-
-    AddSelfAssignableRoleCommand:
-        noSlotsLeft: "The server doesn't have any more self-assignable role slots, you can remove existing self-assignable roles to free up slots."
-        success: "Role **:role** role has been added to the self-assignable list.\nThe server has `:slots` more self-assignable roles slots available."
+        success: "Le rôle **:role** a été ajouté à la liste des rôles auto-assignables. Le serveur a encore `:slots' emplacements de rôles auto-assignables disponibles."
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
@@ -71,105 +63,105 @@ administration:
             everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
-        message: "Le module Artificial Intelligence` a été **:status** pour le :channel channel."
+        message: "Le module `Intelligence Artificielle` a été **:status** pour le canal :channel."
         status:
             enabled: "Activé"
             disabled: "Désactivé"
 
     AliasCommand:
-        noSlotsLeft: "Le serveur n'a plus de slots d'alias, vous pouvez supprimer des alias existants pour libérer des slots."
+        noSlotsLeft: "Le serveur n'a plus d'emplacements d'alias, vous pouvez supprimer des alias existants pour libérer des emplacements."
         alreadyExists: "Il y a déjà un alias appelé `{0}`"
         invalidCommand: "Commande donnée invalide, je ne connais pas de commande appelée `{0}`"
         invalidAlias: "Alias donné invalide, `{0}` n'est pas enregistré comme un alias."
-        created: "L'alias `:alias` a été associé à `:command`\nLe serveur a `:slots` plus de slots d' alias disponibles."
+        created: "L'alias `:alias` a été associé à `:command`\nLe serveur a `:slots` plus de emplacements d'alias disponibles."
         deleted: "L'alias `:alias` a été bien supprimé."
 
     AutoAssignRoleCommand:
         higherInTheHierarchy:
             user: "Le rôle **:role** est positionné plus haut dans la hiérarchie que le(s) rôle(s) que tu as, tu ne peux pas ajouter des rôles avec un rang supérieur au tien."
-            bot: "Le rôle **:role** est positionné plus haut dans la hiérarchie, je ne peux pas donner/supprimer ce rôle des utilisateurs."
-        enabled: ":user **Auto assigner un rôle**  **enabled** and set to **:role**"
-        disabledNow: ":user **Auto assigner un rôle** on user join is now **disabled**."
-        disabled: ":utilisateur **Auto assigner un rôle** à l'inscription de l'utilisateur est actuellement **désactivé**."
-        status: "L' **auto assignation automatique du rôle** est actuellement réglé sur **:role**."
+            bot: "Le rôle **:role** est positionné plus haut dans la hiérarchie, je ne peux pas donner/supprimer ce rôle aux utilisateurs."
+        enabled: ":user **assigner automatiquement un rôle** lorsqu'un utilisateur rejoint le serveur est mainenant ** activé** et donne le rôle **:role**"
+        disabledNow: ":user ** assigner automatiquement un rôle** lorsqu'un utilisateur rejoint le serveur est maintenant **désactivé**."
+        disabled: ":utilisateur * assigner automatiquement un rôle** à l'arrivée d'un nouvel utilisateur est actuellement **désactivé**."
+        status: "L'**assignation automatique de rôle** attribut actuellement le rôle **:role**."
 
     BanCommand:
         mustMentionUser: "Tu dois mentionner l'utilisateur que tu veux bannir."
-        higherRole: "Tu ne peux pas bannir les gens qui ont un rôle supérieur ou le même rôle que toi."
-        userHaveHigherRole: "Je ne peux pas bannir {0}, il/elle a un rôle plus élevé que moi, si tu veux pouvoir le/la bannir, réajuste mon rôle à un rôle supérieur {0}, je te prie."
+        higherRole: "Tu ne peux pas bannir les gens qui ont un rôle supérieur ou égal au tiens."
+        userHaveHigherRole: "Je ne peux pas bannir {0} a un rôle plus élevé que le mien, si tu veux pouvoir bannir {0}, il me faut un rôle supérieur au sien."
         success: "**:target** a été définitivement banni par :user pour \":reason\""
         failedToBan: "Échec du bannissement **:target** dû à une erreur: :error"
 
     CategoriesCommand:
         title: "Statut de la catégorie pour #{0}"
-        status: "emoteEnabled Enabled :emoteDisabledInChannel Disabled in Channel :emoteDisabledGlobally DisabledGlobally Disabled"
-    
+        status: ":emoteEnabled Actives   :emoteDisabledInChannel Inactives dans le Canal   :emoteDisabledGlobally Inactives Globalement"
+
     ChangePrefixCommand:
-        missingArgument: "Caractère manquant `category`, vous devez spécifier la catégorie de commande pour laquelle vous voulez changer/réinitialiser le préfixe."
-        invalidCategory: "Catégorie `category` donnée invalide, il n'y a pas de catégories de commandes qui sont appelées, ou commence par `{0}``."
-        invalidPrefix: "Préfixe de commande donné invalide, `{0}` n'est pas un préfixe valide, tous les préfixes ne doivent **PAS** contenir d'espace et avoir entre 1 et 16 caractères."
+        missingArgument: "Arguement de `catégorie` manquant, vous devez spécifier la catégorie de commande pour laquelle vous voulez changer/réinitialiser le préfixe."
+        invalidCategory: "`Catégorie` fournie invalide, il n'y a pas de catégorie de commandes appelée, ou commençant par `{0}`."
+        invalidPrefix: "Préfixe de commande fourni invalide, `{0}` n'est pas un préfixe valide, les préfixes doivent contenir entre 1 et 16 caractères **MAIS** ne doivent **PAS** contenir d'espace."
         update:
-            global: "Toutes les commandes de chaque catégorie utilisent maintenant le préfixe `:prefix`."
-            category: "Toutes les commandes de la catégorie `:category` utilisent maintenant le préfixe `:prefix`."
+            global: "Les commandes de toutes les catégories utilisent maintenant le préfixe `:prefix`."
+            category: "Les commandes de la catégorie `:category` utilisent maintenant le préfixe `:prefix`."
         reset:
-            global: "Toutes les commandes de chaque catégorie ont été réinitialisées pour utiliser le préfixe `:prefix`."
-            category: "Toutes les commandes de la catégorie `:category` ont été réinitialisées pour utiliser le préfixe `:prefix`."
+            global: "Les commandes de toutes les catégories ont été réinitialisées pour utiliser le préfixe `:prefix`."
+            category: "Les commandes de la catégorie `:category` ont été réinitialisées pour utiliser le préfixe `:prefix`."
 
     ChannelLevelCommand:
-        invalidChannel: "Channel donné invalide, le channel doit être un channel de texte valide."
-        cantTalkInChannel: "Je ne peux pas parler dans le channel {0}, donc aucun utilisateur ne sera récompensé pour avoir parlé dans le channel, si vous voulez que je donne des XP aux utilisateurs, veuillez changer mon niveau de permission pour le channel et je pourrai envoyer des messages dans ce channel."
-        noChannelsWithRewardsDisabled: "Il n' y a actuellement aucun channel avec les récompenses de niveau désactivées, vous pouvez en ajouter un en utilisant le bouton `{0}. <channel>`commande."
-        failedToUpdate: "Si tu n'as pas réussi à sauvegarder les modifications apportées à la base de données, essaie à nouveau, si le problème persiste, contacte un de mes développeurs."
-        listChannels: "Toutes les chaînes mentionnées ci-dessous ont actuellement leurs récompenses de niveau désactivées, toutes les chaînes qui ne sont pas sur cette liste ne sont pas affectées. \n\n:channels"
-        listChannelsTitle: "Channels with their Level Rewards disabled ({0})"
-        success: "The XP rewards for the :channel channel has been **:status**!"
+        invalidChannel: "Channel fourni invalide, le canal doit être un canal de texte valide."
+        cantTalkInChannel: "Je ne peux pas parler dans le canal {0}, donc aucun utilisateur ne sera récompensé pour avoir parlé dans ce canal, si tu veux que je puisse donner des XP aux utilisateurs, tu dois changer mon niveau de permission pour le canal et je pourrai y envoyer des messages."
+        noChannelsWithRewardsDisabled: "Il n' y a actuellement aucun canal avec les récompenses de niveau désactivées, vous pouvez en ajouter un en utilisant la commande `{0} <channel>`."
+        failedToUpdate: "Impossible de sauvegarder les modifications apportées à la base de données, essaie à nouveau, si le problème persiste, contacte l'un de mes développeurs."
+        listChannels: "Toutes les canaux mentionnées ci-dessous ont actuellement leurs récompenses de niveau désactivées, les autres canaux ne sont pas affectées. \n\n:channels"
+        listChannelsTitle: "Canaux avec leurs Récompenses de Niveau désactivées({0})"
+        success: "La récompense d'XP pour le canal :channel est à présent **:status**!"
         status:
-            enabled: "Enabled"
-            disabled: "Disabled"
+            enabled: "Activée"
+            disabled: "Désactivée"
 
     GoodbyeCommand:
-        note: "\nYou can customize the message by using `{0} [message]`"
-        message: "The `Goodbye` module has been **:status** for the :channel channel."
+        note: "\nTu peux personnaliser le message en utilisant `{0} [message]`"
+        message: "Le module `Goodbye` est à présent **:status** pour le canal :channel."
         status:
-            enabled: "Enabled"
-            disabled: "Disabled"
+            enabled: "Activé"
+            disabled: "Désactivé"
 
     GoodbyeMessageCommand:
-        moduleMustBeEnabled: "The `goodbye` module must be enabled to use this command, you can enable the `goodbye` module by using the `{0}` command."
-        message: "The embed option for goodbye messages has been **:status**\n:note"
-        changedToDefault: "Le message du moduleGoodbye` par défaut a été remis."
+        moduleMustBeEnabled: "Le module `goodbye` doit être actif pour utiliser cette commande, tu peux l'activer avec la commande `{0}`."
+        message: "L'option intégrée au message d'aurevoir a été **:status**\n:note"
+        changedToDefault: "Le message du module `Goodbye` par défaut a été remis."
         status:
             enabled: "Activé"
             disabled: "Désactivé"
         note:
-            embed: "Les messages d'au revoir seront désormais envoyés en utilisant les messages avec la couleur : {0}"
-            normal: "Envoyer des messages d'au revoir par des messages normaux."
+            embed: "Les messages d'aurevoir seront désormais envoyés en utilisant les messages avec la couleur : {0}"
+            normal: "Envoyer des messages d'aurevoir par des messages normaux."
 
     IAmCommand:
-        notSelfAssignable: ":role invalide de l'utilisateur, :role n'est pas un rôle auto-assignable."
-        roleIsHigherInTheHierarchy: ":user , Le rôle est plus élevé dans la hiérarchie des rôles, je ne peux pas donner/supprimer le rôle :role à des personnes."
+        notSelfAssignable: ":role rôle invalide, :role n'est pas un rôle auto-assignable."
+        roleIsHigherInTheHierarchy: ":user, Le rôle est plus élevé dans la hiérarchie des rôles, je ne peux pas donner/supprimer le rôle :role."
         message: ":user Tu as maintenant le rôle :role!"
 
     IAmNotCommand:
-        notSelfAssignable: ":role invalide de l'utilisateur, :role n'est pas un rôle auto-assignable."
-        roleIsHigherInTheHierarchy: ":utilisateur Le rôle est plus élevé dans la hiérarchie des rôles, je ne peux pas donner/supprimer le rôle :role à des personnes."
+        notSelfAssignable: ":role rôle invalide, :role n'est pas un rôle auto-assignable."
+        roleIsHigherInTheHierarchy: ":user Le rôle est plus élevé dans la hiérarchie des rôles, je ne peux pas donner/supprimer le rôle :role."
         message: ":user Tu n'as plus le rôle :role!"
 
     KickCommand:
         mustMentionUser: "Tu dois mentionner l'utilisateur que tu veux expulser."
-        higherOrSameRole: "Tu ne peux pas expulser des gens avec un rôle plus élevé, ou ayant le même rôle que toi"
-        cantKickUser: "Je ne peux pas expulser {0}, il/elle a un rôle plus élevé que moi, si vous voulez pouvoir expulser l'utilisateur, veuillez réajuster ma position de rôle au dessus de {0}."
-        success: "**:target** was kicked by :user for \":reason\""
+        higherOrSameRole: "Tu ne peux pas expulser les gens qui ont un rôle supérieur ou égal au tiens."
+        cantKickUser: "Je ne peux pas expulser {0} a un rôle plus élevé que le mien, si tu veux pouvoir expulser {0}, il me faut un rôle supérieur au sien."
+        success: "**:target** a été expulsé par :user pour \":reason\""
         error: "Expulsion échouée **:target** dû à une erreur : :error"
-    
+
     LanguageCommand:
         invalidLanguageCode:  "Code de langue invalide donné, `{0}` n'est pas un code de langue valide, ou il n'est pas encore supporté !"
         changed: "La langue du serveur a été mise à jour avec succès pour utiliser la langue :name !"
-        note: "AvaIre supporte plusieurs langues fournies par l'utilisateur que tu peux sélectionner avec cette commande.  Les traductions peuvent ne pas être 100% exactes ou complètes. Pour sélectionner une langue, utilisez `{0}.  <code>`"
-    
+        note: "AvaIre supporte plusieurs langues fournies par l'utilisateur que tu peux sélectionner avec cette commande. Les traductions peuvent ne pas être à 100% exactes ou complètes. Pour sélectionner une langue, utilisez `{0} <code>`"
+
     LevelAlertsCommand:
-        message: "Les alertes de niveau supérieur a été :status pour le serveur.:note"
-        note: "\nTous les messages de niveau supérieur seront enregistrés dans le canal <##{0}>."
+        message: "Les alertes de niveau supérieur ont été :status pour le serveur.:note"
+        note: "\nTous les messages de niveau supérieur seront enregistrés dans le canal <#{0}>."
         status:
             enabled: "Activé"
             disabled: "Désactivé"
@@ -182,19 +174,19 @@ administration:
             disabled: "Désactivé"
 
     LevelHierarchyCommand:
-        invalidTypeGiven: "Type invalide donné, pour activer ou désactiver la hiérarchie des niveaux, vous devez utiliser \"on\" ou \"off\"."
-        message: "Le niveau supérieur de la hiérarchie a été `:status` pour ce serveur."
-        statusMessage: "La hiérarchie de niveau supérieur est actuellement `:status`, vous pouvez l'activer ou la désactiver avec `:command`."
+        invalidTypeGiven: "Type fourni invalide, pour activer ou désactiver la hiérarchie des niveaux, vous devez utiliser \"on\" ou \"off\"."
+        message: "La hiérarchie de montée en niveau a été `:status` pour ce serveur."
+        statusMessage: "La hiérarchie de montée en niveau est actuellement `:status`, vous pouvez l'activer ou la désactiver avec `:command`."
         status:
             enabled: "Activé"
             disabled: "Désactivéé"
-    
+
     LevelModifierCommand:
-        invalidNumberGiven: "Modificateur donné invalide, le modificateur doit être un pourcentage positif entre `0,01%`et `500%`."
+        invalidNumberGiven: "Modificateur fourni invalide, le modificateur doit être un pourcentage positif entre `0,01%`et `500%`."
         resetToDefault: "Le modificateur de niveau a été réinitialisé en utilisant le modificateur par défaut **:modifier**."
-        changedTo: "The level and experience modifier have been change to **:modifier**."
-        statusMessage: "The server is currently using a **:modifier** modifier for levels and experience.\n\n**Required XP to reach some levels**\n"
-        level: "Level {0}"
+        changedTo: "Le modificateur de niveau et d'expérience est à présent **:modifier**."
+        statusMessage: "Le serveur utilise un modificateur **:modifier** pour les niveaux et l'expérience.\n\n**XP requis pour atteindre certains niveaux**\n"
+        level: "Niveau {0}"
 
     ListAliasesCommand:
         noAliases: "The server doesn't have any aliases right now, you can create one using the\n`{0}alias <alias> <command>` command"

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -50,17 +50,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "The `Artificial Intelligence` module has been **:status** for the :channel channel."

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -50,17 +50,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "Il modulo `Intelligenza Artificiale` è stato **:status** per il canale :channel."

--- a/src/main/resources/langs/nl_NL.yml
+++ b/src/main/resources/langs/nl_NL.yml
@@ -7,7 +7,7 @@ errors:
     mustBeConnectedToVoice: 'Je moet verbonden zijn met een spraak kanaal om dit commando te kunnen gebruiken!' 
     mustBeConnectedToSameChannel: 'Je moet met het zelfde spraak kanaal verbonden zijn als mij {0}!'
     missingMusicQueue: 'Er mist een muziek `query`, je moet een link naar het nummer die je wilt luisteren leveren of tenminste een titel van een nummer!'
-    cantMentionEveryone: "You don't have permissions to mention everyone."
+    cantMentionEveryone: "Je hebt geen toestemming om iedereen te pingen."
     requireLevelFeatureToBeEnabled: 'Om dit commando te kunnen gebruiken, moet je de `Levels en Experience` module aan hebben op de server, je kan een server admin vragen als ze dit aan willen zetten met `{0}`'
     errorOccurredWhileLoading: 'Er is een error voorgekomen onder het laden van {0}, A.U.B opnieuw proberen, als dit probleem niet weg gaat, laat het weten bij een van de developers in de [AvaIre support server](https://discord.gg/gt2FWER).'
 
@@ -40,7 +40,7 @@ administration:
 
     AddReactionRoleCommand:
         emoteDoestBelongToServer: "Die emoticon is niet van deze server, je kan alleen emoticons van deze server gebruiken als reactie emoticons."
-        messageHasNoSlots: "Het bericht heeft geen reactie plekken meer over, je kan bestaande reactio rollen verwijderen om meer ruimte vrij te maken, of verwijder reactie rol berichten om de rol toe te voegen aan meer reactie rol berichten."
+        messageHasNoSlots: "Het bericht heeft geen reactie plekken meer over, je kan bestaande reaction rollen verwijderen om meer ruimte vrij te maken, of verwijder reactie rol berichten om de rol toe te voegen aan meer reactie rol berichten."
         serverHasNoSlots: "Kan geen nieuw reactie rol bericht maken, de server heeft niet meer plek voor reactie rol berichten, je kan bestaande reactie rol berichten verwijderen voor meer ruimte, of voeg je reactie rol toe aan een reactie bericht als hier ruimte voor is."
         success: "De :role rol is geregistreed als een reactie rol voor de :emote emote.\nHet bericht heeft nog `:roleSlots` reactie rol plekken over voor dit bericht, en nog `:messageSlots` reactie berichten over."
 
@@ -49,18 +49,18 @@ administration:
         success: "De **:role** rol is toegevoegd aan de zelf uitgeefbare rollen.\nDe server heeft nog `:slots` plekken over voor zelf uitgeefbare rollen."
 
     AdministrateExperienceCommand:
-        cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
-        failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
-        mustBeAnAdmin: "You must be a server admin to reset everyones XP."
-        invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
-        warning: "Warning!"
+        cantUseForBots: "Je kan geen exp toevoegen, aanpassen of verwijderen voor bot accounts, aangezien deze geen exp krijgen. Noem A.U.B een gewone gebruiker wanneer je dit commando gebruikt."
+        invalidAmountGiven: "De `amount` waarde moet tussen de 0 en de {0} zijn om exp van een user af te pakken of om exp toe te voegen."
+        aboutToResetEverything: "Je staat op het punt om alle EXP van iedereen op de server te resetten, **LET OP** dit kan **NIET** ongedaan worden. Als je zeker weet dat je wilt doorgaan, run het commando om alle exp van alle gebruikers te resetten.\n\n```:command server-reset :token```\nDit commando werkt alleen voor 60 seconden, na deze tijd wordt het token ongeldig en zal het commando opnieuw gebruikt moeten worden voor een nieuw token."
+        failedToSaveChanges: "Gefaald met het opslaan van de veranderingen naar de database, probeer A.U.B opnieuw, als deze error blijft gebeuren, neem dan contact op met support in de officiele [AvaIre support server](https://discord.gg/gt2FWER)."
+        mustBeAnAdmin: "Je moet een server admin zijn om iedereens EXP te resetten."
+        invalidSecurityToken: "Ongeldig security token gegeven, geef A.U.B een geldig security token om de EXP van alle servers te resetten."
+        warning: "Waarschuwing!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
-            reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            add: "**:amount** EXP gegeven aan :target, ze hebben nu **:newAmount** XP."
+            take: "**:amount** XP weg genomen van :target, ze hebben nu **:newAmount** XP."
+            reset: ":target zijn EXP is succesvol gereset."
+            everything: "De EXP van iedereen op de server is compleet gereset!"
 
     AiCommand:
         message: "De `Artificial Intelligence` module is veranderd naar **:status** voor het :channel kanaal."

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -50,17 +50,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "The `Artificial Intelligence` module has been **:status** for the :channel channel."

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -50,17 +50,17 @@ administration:
 
     AdministrateExperienceCommand:
         cantUseForBots: "You can't add, remove, or reset XP for bot accounts since they don't earn any, please select a normal user when using this command."
-        invalidAmountGiven: "The `amount` property must between 1 and {0} add or take XP from a user."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        invalidAmountGiven: "The `amount` property must be between 1 and {0} to add or take XP from a user."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "Failed to save the changes to the database, please try again, if the error continues to happen, please contact support on the official [AvaIre support server](https://discord.gg/gt2FWER)."
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
         warning: "Warning!"
         success:
-            add: "**:amount** XP have been given to :target, they now have **:newAmount** XP."
-            take: "**:amount** XP have been taken from :target, they now have **:newAmount** XP."
+            add: "**:amount** XP has been given to :target, they now have **:newAmount** XP."
+            take: "**:amount** XP has been taken from :target, they now have **:newAmount** XP."
             reset: ":target has successfully had their XP reset."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "The `Artificial Intelligence` module has been **:status** for the :channel channel."

--- a/src/main/resources/langs/zh_SI.yml
+++ b/src/main/resources/langs/zh_SI.yml
@@ -50,7 +50,7 @@ administration:
     AdministrateExperienceCommand:
         cantUseForBots: "您不能为bot帐户添加、删除或重置XP，因为这些帐户不能赚取任何利润，请在使用此命令时选择一个普通用户."
         invalidAmountGiven: "这个 `amount` 属性必须介于 1 和 {0} 添加或接受用户的经验."
-        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command have to be ran again to get a new token."
+        aboutToResetEverything: "You're about to reset the XP for everyone on the entire server, note that this action **CAN NOT** be reversed. If you're sure you wanna continue, run the command to completely reset the servers XP.\n\n```:command server-reset :token```\nThis command will only work for 60 seconds, after that time the token becomes invalid and the command has to be ran again to get a new token."
         failedToSaveChanges: "无法将更改保存到数据库，请重试，如果错误继续发生，请与官方[AvaIre支持服务器]上的支持人员联系(https://discord.gg/gt2FWER). 如果你不懂如何操作，请联系我QQ1653573879来帮助操作"
         mustBeAnAdmin: "You must be a server admin to reset everyones XP."
         invalidSecurityToken: "Invalid security token given, please provide the correct security token to reset all the servers XP."
@@ -59,7 +59,7 @@ administration:
             add: "**:amount** 经验已经被赋予 :target, 他们现在有 **:newAmount** 经验."
             take: "**:amount** 经验已从 :target, 他们现在有 **:newAmount** 经验."
             reset: ":target 已成功重置其经验."
-            everything: "Everyone on the entire server have now had their XP completely reset!"
+            everything: "Everyone on the entire server has now had their XP completely reset!"
 
     AiCommand:
         message: "“人工智能”模块 **:status** 为 :channel 频道."


### PR DESCRIPTION
This fixes a bug where some self-hosters who used a none-english language on the machine they hosted the bot on, to not be able to run the database migrations due the local output and time formats are parsed incorrectly.