### PR TITLE
Create mute, unmute, and muterole commands (#109)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.108'
+version = '0.9.109'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/AvaIre.java
+++ b/src/main/java/com/avairebot/AvaIre.java
@@ -65,6 +65,7 @@ import com.avairebot.language.I18n;
 import com.avairebot.level.LevelManager;
 import com.avairebot.metrics.Metrics;
 import com.avairebot.middleware.*;
+import com.avairebot.mute.MuteManager;
 import com.avairebot.plugin.PluginLoader;
 import com.avairebot.plugin.PluginManager;
 import com.avairebot.scheduler.ScheduleHandler;
@@ -136,6 +137,7 @@ public class AvaIre {
     private final IntelligenceManager intelligenceManager;
     private final PluginManager pluginManager;
     private final VoteManager voteManager;
+    private final MuteManager muteManger;
     private final ShardEntityCounter shardEntityCounter;
     private final EventEmitter eventEmitter;
     private final BotAdmin botAdmins;
@@ -391,6 +393,9 @@ public class AvaIre {
         log.info("Preparing vote manager");
         voteManager = new VoteManager(this);
 
+        log.info("Preparing mute manager");
+        muteManger = new MuteManager(this);
+
         log.info("Preparing Lavalink");
         AudioHandler.setAvaire(this);
         LavalinkManager.LavalinkManagerHolder.lavalink.start(this);
@@ -518,6 +523,10 @@ public class AvaIre {
 
     public VoteManager getVoteManager() {
         return voteManager;
+    }
+
+    public MuteManager getMuteManger() {
+        return muteManger;
     }
 
     public WebServlet getServlet() {

--- a/src/main/java/com/avairebot/Constants.java
+++ b/src/main/java/com/avairebot/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
     public static final String LOG_TYPES_TABLE_NAME = "log_types";
     public static final String REACTION_ROLES_TABLE_NAME = "reaction_roles";
     public static final String PURCHASES_TABLE_NAME = "purchases";
+    public static final String MUTE_TABLE_NAME = "mutes";
 
     // Package Specific Information
     public static final String PACKAGE_MIGRATION_PATH = "com.avairebot.database.migrate";

--- a/src/main/java/com/avairebot/commands/administration/MuteCommand.java
+++ b/src/main/java/com/avairebot/commands/administration/MuteCommand.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.commands.administration;
+
+import com.avairebot.AvaIre;
+import com.avairebot.commands.CommandMessage;
+import com.avairebot.contracts.commands.*;
+import com.avairebot.database.transformers.GuildTransformer;
+import com.avairebot.modlog.Modlog;
+import com.avairebot.modlog.ModlogAction;
+import com.avairebot.modlog.ModlogType;
+import com.avairebot.time.Carbon;
+import com.avairebot.utilities.MentionableUtil;
+import com.avairebot.utilities.NumberUtil;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.User;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MuteCommand extends MuteableCommand {
+
+    private final Pattern timeRegEx = Pattern.compile("([0-9]+[w|d|h|m|s])");
+
+    public MuteCommand(AvaIre avaire) {
+        super(avaire, false);
+    }
+
+    @Override
+    public String getName() {
+        return "Mute Command";
+    }
+
+    @Override
+    public String getDescription(@Nullable CommandContext context) {
+        return String.format(
+            "Mutes the mentioned user by giving them the %s role, if a time is specified the user will automatically be unmuted again after the time has elapsed, this action will be reported to any channel that has modloging enabled.",
+            getMuteRoleNameFromContext(context)
+        );
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Collections.singletonList(
+            "`:command <user> [time] [reason]` - Mutes the mentioned user with the given reason for the given amount of time."
+        );
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Arrays.asList(
+            "`:command @Senither Spams too much` - Mutes the user permanently.",
+            "`:command @Senither 30m Calm down` - Mutes the user for 30 minutes.",
+            "`:command @Senither 1d` - Mutes the user for 1 day with no reason."
+        );
+    }
+
+    @Override
+    public List<Class<? extends Command>> getRelations() {
+        return Arrays.asList(
+            UnmuteCommand.class,
+            MuteRoleCommand.class
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Collections.singletonList("mute");
+    }
+
+    @Override
+    public List<String> getMiddleware() {
+        return Arrays.asList(
+            "require:user,text.manage_messages",
+            "require:bot,general.manage_roles",
+            "throttle:guild,1,4"
+        );
+    }
+
+    @Nonnull
+    @Override
+    public List<CommandGroup> getGroups() {
+        return Collections.singletonList(CommandGroups.MODERATION);
+    }
+
+    @Override
+    public boolean onCommand(CommandMessage context, String[] args) {
+        GuildTransformer transformer = context.getGuildTransformer();
+        if (transformer == null) {
+            return sendErrorMessage(context, "errors.errorOccurredWhileLoading", "server settings");
+        }
+
+        if (transformer.getModlog() == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requiresModlogToBeSet", prefix));
+        }
+
+        if (transformer.getMuteRole() == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requireMuteRoleToBeSet", prefix));
+        }
+
+        Role muteRole = context.getGuild().getRoleById(transformer.getMuteRole());
+        if (muteRole == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requireMuteRoleToBeSet", prefix));
+        }
+
+        if (!context.getGuild().getSelfMember().canInteract(muteRole)) {
+            return sendErrorMessage(context, context.i18n("muteRoleIsPositionedHigher", muteRole.getAsMention()));
+        }
+
+        if (args.length == 0) {
+            return sendErrorMessage(context, "errors.missingArgument", "user");
+        }
+
+        User user = MentionableUtil.getUser(context, args);
+        if (user == null) {
+            return sendErrorMessage(context, context.i18n("invalidUserMentioned"));
+        }
+
+        Carbon expiresAt = null;
+        if (args.length > 1) {
+            expiresAt = parseTime(args[1]);
+        }
+
+        if (expiresAt != null && expiresAt.copy().subSeconds(61).isPast()) {
+            return sendErrorMessage(context, context.i18n("invalidTimeGiven"));
+        }
+
+        String reason = generateMessage(Arrays.copyOfRange(args, expiresAt == null ? 1 : 2, args.length));
+        ModlogType type = expiresAt == null ? ModlogType.MUTE : ModlogType.TEMP_MUTE;
+
+        final Carbon finalExpiresAt = expiresAt;
+        context.getGuild().getController().addRolesToMember(
+            context.getGuild().getMember(user), muteRole
+        ).reason(reason).queue(aVoid -> {
+            ModlogAction modlogAction = new ModlogAction(
+                type, context.getAuthor(), user,
+                finalExpiresAt != null
+                    ? finalExpiresAt.toDayDateTimeString() + " (" + finalExpiresAt.diffForHumans(true) + ")" + "\n" + reason
+                    : "\n" + reason
+            );
+
+            String caseId = Modlog.log(avaire, context, modlogAction);
+            Modlog.notifyUser(user, context.getGuild(), modlogAction, caseId);
+
+            try {
+                avaire.getMuteManger().registerMute(caseId, context.getGuild().getIdLong(), user.getIdLong(), finalExpiresAt);
+
+                context.makeSuccess(context.i18n("userHasBeenMuted"))
+                    .set("target", user.getAsMention())
+                    .set("time", finalExpiresAt == null
+                        ? context.i18n("time.permanently")
+                        : context.i18n("time.forFormat", finalExpiresAt.diffForHumans(true)))
+                    .queue();
+            } catch (SQLException e) {
+                AvaIre.getLogger().error(e.getMessage(), e);
+                context.makeError("Failed to save the guild settings: " + e.getMessage()).queue();
+            }
+        });
+
+        return true;
+    }
+
+    private Carbon parseTime(String string) {
+        Matcher matcher = timeRegEx.matcher(string);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        Carbon time = Carbon.now().addSecond();
+        do {
+            String group = matcher.group();
+
+            String type = group.substring(group.length() - 1, group.length());
+            int timeToAdd = NumberUtil.parseInt(group.substring(0, group.length() - 1));
+
+            switch (type.toLowerCase()) {
+                case "w":
+                    time.addWeeks(timeToAdd);
+                    break;
+
+                case "d":
+                    time.addDays(timeToAdd);
+                    break;
+
+                case "h":
+                    time.addHours(timeToAdd);
+                    break;
+
+                case "m":
+                    time.addMinutes(timeToAdd);
+                    break;
+
+                case "s":
+                    time.addSeconds(timeToAdd);
+                    break;
+            }
+        } while (matcher.find());
+
+        return time;
+    }
+
+    private String generateMessage(String[] args) {
+        return args.length == 0 ?
+            "No reason was given." :
+            String.join(" ", args);
+    }
+}

--- a/src/main/java/com/avairebot/commands/administration/MuteRoleCommand.java
+++ b/src/main/java/com/avairebot/commands/administration/MuteRoleCommand.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.commands.administration;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.commands.CommandMessage;
+import com.avairebot.contracts.commands.Command;
+import com.avairebot.contracts.commands.CommandGroup;
+import com.avairebot.contracts.commands.CommandGroups;
+import com.avairebot.database.transformers.GuildTransformer;
+import com.avairebot.utilities.MentionableUtil;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Role;
+
+import javax.annotation.Nonnull;
+import java.awt.*;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MuteRoleCommand extends Command {
+
+    public MuteRoleCommand(AvaIre avaire) {
+        super(avaire, false);
+    }
+
+    @Override
+    public String getName() {
+        return "Mute Role Command";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Can be used to set, create, or reset the mute role used for mute related commands on the server, the mute role is what is assigned to users when they're muted, preventing them from talking or speaking in voice channels.";
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Arrays.asList(
+            "`:command set <role>` - Sets the mute role to the given role.",
+            "`:command create-role` - Creates a new role called \"Muted\".",
+            "`:command reset` - Resets the mute role, disabling the mute feature."
+        );
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Arrays.asList(
+            "`:command set @Talk Too Much` - Sets the muted role to the \"Talk Too Much\" role.",
+            "`:command set 601361125220810765` - Sets the muted role to the given ID.",
+            "`:command create-role` - Creates and sets up a new muted role.",
+            "`:command reset` - Resets the mute role."
+        );
+    }
+
+    @Override
+    public List<Class<? extends Command>> getRelations() {
+        return Arrays.asList(
+            MuteCommand.class,
+            UnmuteCommand.class
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Collections.singletonList("muterole");
+    }
+
+    @Override
+    public List<String> getMiddleware() {
+        return Arrays.asList(
+            "require:user,general.manage_server,general.manage_roles",
+            "throttle:guild,1,5"
+        );
+    }
+
+    @Nonnull
+    @Override
+    public List<CommandGroup> getGroups() {
+        return Collections.singletonList(CommandGroups.MODERATION);
+    }
+
+    @Override
+    public boolean onCommand(CommandMessage context, String[] args) {
+        GuildTransformer guildTransformer = context.getGuildTransformer();
+        if (guildTransformer == null) {
+            return sendErrorMessage(context, "errors.errorOccurredWhileLoading", "server settings");
+        }
+
+        if (args.length == 0) {
+            return sendMutedRole(context, guildTransformer);
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "set":
+                return setMutedRole(context, guildTransformer, Arrays.copyOfRange(args, 1, args.length));
+
+            case "create-role":
+                return createMutedRole(context, guildTransformer);
+
+            case "reset":
+                return resetRole(context, guildTransformer);
+        }
+
+        return sendErrorMessage(context, "errors.missingArgument", "option");
+    }
+
+    private boolean sendMutedRole(CommandMessage context, GuildTransformer guildTransformer) {
+        if (guildTransformer.getMuteRole() == null) {
+            context.makeInfo(context.i18n("noMuteRoleSet"))
+                .set("command", generateCommandTrigger(context.getMessage()))
+                .queue();
+
+            return true;
+        }
+
+        Role role = context.getGuild().getRoleById(guildTransformer.getMuteRole());
+        if (role == null) {
+            context.makeInfo(context.i18n("noMuteRoleSet"))
+                .set("command", generateCommandTrigger(context.getMessage()))
+                .queue();
+
+            return true;
+        }
+
+        context.makeInfo(context.i18n("usingRoleMessage"))
+            .set("role", role.getAsMention())
+            .queue();
+
+        return true;
+    }
+
+    private boolean setMutedRole(CommandMessage context, GuildTransformer guildTransformer, String[] args) {
+        Role role = MentionableUtil.getRole(context.getMessage(), args);
+        if (role == null) {
+            return sendErrorMessage(context, context.i18n("roleDoesntExists", String.join(" ", args)));
+        }
+
+        if (!context.getGuild().getSelfMember().canInteract(role)) {
+            return sendErrorMessage(context, context.i18n("rolePositionedHigher", role.getAsMention()));
+        }
+
+        return updateMutedRole(context, guildTransformer, role.getId());
+    }
+
+    private boolean createMutedRole(CommandMessage context, GuildTransformer guildTransformer) {
+        List<Role> muted = context.getGuild().getRolesByName("Muted", true);
+        if (!muted.isEmpty()) {
+            return updateMutedRole(context, guildTransformer, muted.get(0).getId());
+        }
+
+        if (!context.getGuild().getSelfMember().hasPermission(Permission.MANAGE_ROLES)) {
+            return sendErrorMessage(context, context.i18n("cantCreateRoleDueToPermissions"));
+        }
+
+        context.getGuild().getController().createRole()
+            .setName("Muted")
+            .setColor(Color.decode("#e91b6a"))
+            .setPermissions(
+                Permission.MESSAGE_READ,
+                Permission.MESSAGE_HISTORY
+            )
+            .queue(role -> updateMutedRole(context, guildTransformer, role.getId()));
+
+        return true;
+    }
+
+    private boolean resetRole(CommandMessage context, GuildTransformer guildTransformer) {
+        return updateMutedRole(context, guildTransformer, null);
+    }
+
+    private boolean updateMutedRole(CommandMessage context, GuildTransformer guildTransformer, String value) {
+        try {
+            avaire.getDatabase().newQueryBuilder(Constants.GUILD_TABLE_NAME)
+                .where("id", context.getGuild().getId())
+                .update(statement -> statement.set("mute_role", value));
+
+            guildTransformer.setMuteRole(value);
+
+            context.makeSuccess(
+                context.i18n(value == null ? "roleHasBeenRemoved" : "nowUsingRole")
+            ).set("roleId", value).queue();
+
+            return true;
+        } catch (SQLException e) {
+            AvaIre.getLogger().error(e.getMessage(), e);
+            context.makeError("Failed to save the guild settings: " + e.getMessage()).queue();
+
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/avairebot/commands/administration/UnmuteCommand.java
+++ b/src/main/java/com/avairebot/commands/administration/UnmuteCommand.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.commands.administration;
+
+import com.avairebot.AvaIre;
+import com.avairebot.commands.CommandMessage;
+import com.avairebot.contracts.commands.*;
+import com.avairebot.database.transformers.GuildTransformer;
+import com.avairebot.modlog.Modlog;
+import com.avairebot.modlog.ModlogAction;
+import com.avairebot.modlog.ModlogType;
+import com.avairebot.utilities.MentionableUtil;
+import com.avairebot.utilities.RoleUtil;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.User;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class UnmuteCommand extends MuteableCommand {
+
+    public UnmuteCommand(AvaIre avaire) {
+        super(avaire, false);
+    }
+
+    @Override
+    public String getName() {
+        return "Unmute Command";
+    }
+
+    @Override
+    public String getDescription(@Nullable CommandContext context) {
+        return String.format(
+            "Unmutes the mentioned user by removing the %s role from them, this action will be reported to any channel that has modloging enabled.",
+            getMuteRoleNameFromContext(context)
+        );
+    }
+
+    @Override
+    public List<String> getUsageInstructions() {
+        return Collections.singletonList(
+            "`:command <user> [reason]` - Unmutes the given user."
+        );
+    }
+
+    @Override
+    public List<String> getExampleUsage() {
+        return Arrays.asList(
+            "`:command @Senither` - Unmutes the user with no reason given.",
+            "`:command @Senither Calmed down` - Unmutes the user with the given reason."
+        );
+    }
+
+    @Override
+    public List<Class<? extends Command>> getRelations() {
+        return Arrays.asList(
+            MuteCommand.class,
+            MuteRoleCommand.class
+        );
+    }
+
+    @Override
+    public List<String> getTriggers() {
+        return Collections.singletonList("unmute");
+    }
+
+    @Override
+    public List<String> getMiddleware() {
+        return Arrays.asList(
+            "require:user,text.manage_messages",
+            "require:bot,general.manage_roles",
+            "throttle:guild,1,4"
+        );
+    }
+
+    @Nonnull
+    @Override
+    public List<CommandGroup> getGroups() {
+        return Collections.singletonList(CommandGroups.MODERATION);
+    }
+
+    @Override
+    public boolean onCommand(CommandMessage context, String[] args) {
+        GuildTransformer transformer = context.getGuildTransformer();
+        if (transformer == null) {
+            return sendErrorMessage(context, "errors.errorOccurredWhileLoading", "server settings");
+        }
+
+        if (transformer.getModlog() == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requiresModlogToBeSet", prefix));
+        }
+
+        if (transformer.getMuteRole() == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requireMuteRoleToBeSet", prefix));
+        }
+
+        Role muteRole = context.getGuild().getRoleById(transformer.getMuteRole());
+        if (muteRole == null) {
+            String prefix = generateCommandPrefix(context.getMessage());
+            return sendErrorMessage(context, context.i18n("requireMuteRoleToBeSet", prefix));
+        }
+
+        if (!context.getGuild().getSelfMember().canInteract(muteRole)) {
+            return sendErrorMessage(context, context.i18n("muteRoleIsPositionedHigher", muteRole.getAsMention()));
+        }
+
+        if (args.length == 0) {
+            return sendErrorMessage(context, "errors.missingArgument", "user");
+        }
+
+        User user = MentionableUtil.getUser(context, args);
+        if (user == null) {
+            return sendErrorMessage(context, context.i18n("invalidUserMentioned"));
+        }
+
+        if (!RoleUtil.hasRole(context.getGuild().getMember(user), muteRole)) {
+            return sendErrorMessage(context, context.i18n("userDoesntHaveMuteRole", user.getAsMention()));
+        }
+
+        String reason = generateMessage(Arrays.copyOfRange(args, 1, args.length));
+        context.getGuild().getController().removeSingleRoleFromMember(
+            context.getGuild().getMember(user), muteRole
+        ).reason(reason).queue(aVoid -> {
+            ModlogAction modlogAction = new ModlogAction(
+                ModlogType.UNMUTE, context.getAuthor(), user, reason
+            );
+
+            String caseId = Modlog.log(avaire, context, modlogAction);
+            Modlog.notifyUser(user, context.getGuild(), modlogAction, caseId);
+
+            try {
+                avaire.getMuteManger().unregisterMute(context.getGuild().getIdLong(), user.getIdLong());
+
+                context.makeSuccess(context.i18n("userHasBeenUnmuted"))
+                    .set("target", user.getAsMention())
+                    .queue();
+            } catch (SQLException e) {
+                AvaIre.getLogger().error(e.getMessage(), e);
+                context.makeError("Failed to save the guild settings: " + e.getMessage()).queue();
+            }
+        });
+
+        return true;
+    }
+
+    private String generateMessage(String[] args) {
+        return args.length == 0 ?
+            "No reason was given." :
+            String.join(" ", args);
+    }
+}

--- a/src/main/java/com/avairebot/contracts/commands/MuteableCommand.java
+++ b/src/main/java/com/avairebot/contracts/commands/MuteableCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.contracts.commands;
+
+import com.avairebot.AvaIre;
+import com.avairebot.database.transformers.GuildTransformer;
+import net.dv8tion.jda.core.entities.Role;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class MuteableCommand extends Command {
+
+    /**
+     * Creates the given command instance by calling {@link Command#Command(AvaIre, boolean)} with allowDM set to true.
+     *
+     * @param avaire The AvaIre class instance.
+     */
+    public MuteableCommand(AvaIre avaire) {
+        super(avaire);
+    }
+
+    /**
+     * Creates the given command instance with the given
+     * AvaIre instance and the allowDM settings.
+     *
+     * @param avaire  The AvaIre class instance.
+     * @param allowDM Determines if the command can be used in DMs.
+     */
+    public MuteableCommand(AvaIre avaire, boolean allowDM) {
+        super(avaire, allowDM);
+    }
+
+    /**
+     * Gets the name of the role used for muting users, if a valid mute role has been setup for
+     * the server, the role will be returned in a mentionable format, however if no valid role
+     * have been setup for the server the string "`Muted`" will be returned instead.
+     *
+     * @param context The command context that should be used to get the muted role name.
+     * @return The name of the role used for muting users for the given command context.
+     */
+    @Nonnull
+    protected String getMuteRoleNameFromContext(@Nullable CommandContext context) {
+        if (context != null && context.getGuildTransformer() != null) {
+            GuildTransformer transformer = context.getGuildTransformer();
+            if (transformer.getMuteRole() != null) {
+                Role muteRole = context.getGuild().getRoleById(transformer.getMuteRole());
+                if (muteRole != null) {
+                    return muteRole.getAsMention();
+                }
+            }
+        }
+        return "`Muted`";
+    }
+}

--- a/src/main/java/com/avairebot/database/controllers/GuildController.java
+++ b/src/main/java/com/avairebot/database/controllers/GuildController.java
@@ -51,12 +51,12 @@ public class GuildController {
     private static final Logger log = LoggerFactory.getLogger(GuildController.class);
 
     private static final String[] requiredGuildColumns = new String[]{
-        "guild_types.name as type_name", "guild_types.limits as type_limits",
-        "guilds.id", "guilds.partner", "guilds.name", "guilds.icon", "guilds.local", "guilds.channels", "guilds.modules", "guilds.level_roles",
-        "guilds.level_modifier", "guilds.claimable_roles", "guilds.prefixes", "guilds.aliases", "guilds.modlog_case", "guilds.modlog",
-        "guilds.default_volume", "guilds.dj_level", "guilds.dj_role", "guilds.autorole", "guilds.level_channel",
-        "guilds.level_alerts", "guilds.levels", "guilds.hierarchy", "guilds.music_channel_text",
-        "guilds.music_channel_voice", "music_messages", "guilds.level_exempt_channels"
+        "guild_types.name as type_name", "guild_types.limits as type_limits", "guilds.id", "guilds.partner", "guilds.name", "guilds.icon",
+        "guilds.local", "guilds.channels", "guilds.modules", "guilds.level_roles", "guilds.level_modifier", "guilds.claimable_roles",
+        "guilds.music_channel_text", "guilds.music_channel_voice", "guilds.music_messages", "guilds.level_exempt_channels",
+        "guilds.prefixes", "guilds.aliases", "guilds.modlog_case", "guilds.modlog", "guilds.mute_role", "guilds.autorole",
+        "guilds.level_channel", "guilds.level_alerts", "guilds.levels", "guilds.hierarchy",
+        "guilds.default_volume", "guilds.dj_level", "guilds.dj_role"
     };
 
     /**

--- a/src/main/java/com/avairebot/database/migrate/migrations/AddMuteRoleColumnToGuildsTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/AddMuteRoleColumnToGuildsTableMigration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.connections.MySQL;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class AddMuteRoleColumnToGuildsTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Wed, Jul 17, 2019 12:30 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        if (schema.hasColumn(Constants.GUILD_TABLE_NAME, "mute_role")) {
+            return true;
+        }
+
+        if (schema.getDbm().getConnection() instanceof MySQL) {
+            schema.getDbm().queryUpdate(String.format(
+                "ALTER TABLE `%s` ADD `mute_role` VARCHAR(32) NULL DEFAULT NULL AFTER `modlog_case`;",
+                Constants.GUILD_TABLE_NAME
+            ));
+        } else {
+            schema.getDbm().queryUpdate(String.format(
+                "ALTER TABLE `%s` ADD `mute_role` VARCHAR(32) NULL DEFAULT NULL;",
+                Constants.GUILD_TABLE_NAME
+            ));
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        if (!schema.hasColumn(Constants.GUILD_TABLE_NAME, "mute_role")) {
+            return true;
+        }
+
+        schema.getDbm().queryUpdate(String.format(
+            "ALTER TABLE `%s` DROP `mute_role`;",
+            Constants.GUILD_TABLE_NAME
+        ));
+
+        return true;
+    }
+}

--- a/src/main/java/com/avairebot/database/migrate/migrations/CreateMuteTableMigration.java
+++ b/src/main/java/com/avairebot/database/migrate/migrations/CreateMuteTableMigration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.database.migrate.migrations;
+
+import com.avairebot.Constants;
+import com.avairebot.contracts.database.migrations.Migration;
+import com.avairebot.database.schema.Schema;
+
+import java.sql.SQLException;
+
+public class CreateMuteTableMigration implements Migration {
+
+    @Override
+    public String created_at() {
+        return "Sat, Jul 13, 2019 1:41 PM";
+    }
+
+    @Override
+    public boolean up(Schema schema) throws SQLException {
+        return schema.createIfNotExists(Constants.MUTE_TABLE_NAME, table -> {
+            table.Long("guild_id").unsigned();
+            table.Long("modlog_id").unsigned();
+            table.DateTime("expires_in").nullable();
+            table.Timestamps();
+        });
+    }
+
+    @Override
+    public boolean down(Schema schema) throws SQLException {
+        return schema.dropIfExists(Constants.MUTE_TABLE_NAME);
+    }
+}

--- a/src/main/java/com/avairebot/database/transformers/GuildTransformer.java
+++ b/src/main/java/com/avairebot/database/transformers/GuildTransformer.java
@@ -63,6 +63,7 @@ public class GuildTransformer extends Transformer {
     private String modlog = null;
     private String musicChannelText = null;
     private String musicChannelVoice = null;
+    private String muteRole = null;
     private String djRole = null;
     private int modlogCase = 0;
     private int defaultVolume = 100;
@@ -99,6 +100,7 @@ public class GuildTransformer extends Transformer {
             levelModifier = data.getDouble("level_modifier", -1);
             autorole = data.getString("autorole");
             modlog = data.getString("modlog");
+            muteRole = data.getString("mute_role");
             musicChannelText = data.getString("music_channel_text");
             musicChannelVoice = data.getString("music_channel_voice");
             musicMessages = data.getBoolean("music_messages", true);
@@ -326,6 +328,14 @@ public class GuildTransformer extends Transformer {
 
     public void setModlogCase(int modlogCase) {
         this.modlogCase = modlogCase;
+    }
+
+    public String getMuteRole() {
+        return muteRole;
+    }
+
+    public void setMuteRole(String muteRole) {
+        this.muteRole = muteRole;
     }
 
     public Map<String, String> getSelfAssignableRoles() {

--- a/src/main/java/com/avairebot/handlers/adapter/MemberEventAdapter.java
+++ b/src/main/java/com/avairebot/handlers/adapter/MemberEventAdapter.java
@@ -94,6 +94,17 @@ public class MemberEventAdapter extends EventAdapter {
             }
         }
 
+        // Re-mutes the user if a valid mute role have been setup for the guild
+        // and the user is still registered as muted for the server.
+        if (transformer.getMuteRole() != null) {
+            Role mutedRole = event.getGuild().getRoleById(transformer.getMuteRole());
+            if (canGiveRole(event, mutedRole) && avaire.getMuteManger().isMuted(event.getGuild().getIdLong(), event.getUser().getIdLong())) {
+                event.getGuild().getController().addRolesToMember(
+                    event.getMember(), mutedRole
+                ).queue();
+            }
+        }
+
         if (event.getUser().isBot()) {
             return;
         }

--- a/src/main/java/com/avairebot/handlers/adapter/RoleEventAdapter.java
+++ b/src/main/java/com/avairebot/handlers/adapter/RoleEventAdapter.java
@@ -73,10 +73,27 @@ public class RoleEventAdapter extends EventAdapter {
             return;
         }
 
+        handleMuteRole(event, transformer);
         handleAutoroles(event, transformer);
         handleLevelRoles(event, transformer);
         handleMusicDjRole(event, transformer);
         handleSelfAssignableRoles(event, transformer);
+    }
+
+    private void handleMuteRole(RoleDeleteEvent event, GuildTransformer transformer) {
+        if (transformer.getMuteRole() == null || !event.getRole().getId().equals(transformer.getMuteRole())) {
+            return;
+        }
+
+        try {
+            transformer.setMuteRole(null);
+            avaire.getDatabase().newQueryBuilder(Constants.GUILD_TABLE_NAME)
+                .useAsync(true)
+                .where("id", event.getGuild().getId())
+                .update(statement -> statement.set("mute_role", null));
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     private void handleAutoroles(RoleDeleteEvent event, GuildTransformer transformer) {

--- a/src/main/java/com/avairebot/modlog/Modlog.java
+++ b/src/main/java/com/avairebot/modlog/Modlog.java
@@ -136,10 +136,28 @@ public class Modlog {
             case BAN:
             case SOFT_BAN:
             case UNBAN:
+            case UNMUTE:
                 builder
                     .addField("User", action.getStringifiedTarget(), true)
                     .addField("Moderator", action.getStringifiedModerator(), true)
                     .addField("Reason", formatReason(transformer, action.getMessage()), false);
+                break;
+
+            case MUTE:
+            case TEMP_MUTE:
+                //noinspection ConstantConditions
+                split = action.getMessage().split("\n");
+                builder
+                    .addField("User", action.getStringifiedTarget(), true)
+                    .addField("Moderator", action.getStringifiedModerator(), true);
+
+                if (split[0].length() > 0) {
+                    builder.addField("Expires At", split[0], true);
+                }
+
+                builder.addField("Reason", formatReason(transformer, String.join("\n",
+                    Arrays.copyOfRange(split, 1, split.length)
+                )), false);
                 break;
 
             case PURGE:

--- a/src/main/java/com/avairebot/modlog/ModlogType.java
+++ b/src/main/java/com/avairebot/modlog/ModlogType.java
@@ -69,7 +69,22 @@ public enum ModlogType {
     /**
      * Represents when a user is pardoned for an old modlog case.
      */
-    PARDON(8, "Pardon", null, false, false, MessageType.SUCCESS.getColor());
+    PARDON(8, "Pardon", null, false, false, MessageType.SUCCESS.getColor()),
+
+    /**
+     * Represents when a user is muted from a server.
+     */
+    MUTE(9, "Mute", "\uD83D\uDD07", true, true, MessageType.WARNING.getColor()),
+
+    /**
+     * Represents when a user is muted temporarily from a server.
+     */
+    TEMP_MUTE(10, "Temp Mute", "\uD83D\uDD07", true, true, MessageType.WARNING.getColor()),
+
+    /**
+     * Represents when a user is unmuted in a server.
+     */
+    UNMUTE(11, "Unmute", "\uD83D\uDD0A", true, false, MessageType.SUCCESS.getColor());
 
     final int id;
     final String name;
@@ -83,7 +98,7 @@ public enum ModlogType {
         this(id, name, emote, notifyable, true, color);
     }
 
-    ModlogType(int id, String name, String emote, boolean notifyable, boolean punishment, Color color) {
+    ModlogType(int id, String name, @Nullable String emote, boolean notifyable, boolean punishment, Color color) {
         this.id = id;
         this.name = name;
         this.emote = emote;

--- a/src/main/java/com/avairebot/mute/MuteContainer.java
+++ b/src/main/java/com/avairebot/mute/MuteContainer.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.mute;
+
+import com.avairebot.language.I18n;
+import com.avairebot.time.Carbon;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.ScheduledFuture;
+
+@SuppressWarnings("WeakerAccess")
+public class MuteContainer {
+
+    private final long guildId;
+    private final long userId;
+    private final Carbon expiresAt;
+    private ScheduledFuture<?> schedule;
+
+    /**
+     * Creates a mute container using the given guild ID, user ID, and expiration time.
+     *
+     * @param guildId   The ID of the guild the mute is registered to.
+     * @param userId    The ID of the user the mute is registered for.
+     * @param expiresAt The date and time the mute should expire,
+     *                  or {@code NULL} for permanent mutes.
+     */
+    MuteContainer(long guildId, long userId, @Nullable Carbon expiresAt) {
+        this.guildId = guildId;
+        this.userId = userId;
+        this.expiresAt = expiresAt;
+        this.schedule = null;
+    }
+
+    /**
+     * Gets the ID of the guild the mute is registered for.
+     *
+     * @return The guild ID the mute is registered for.
+     */
+    public long getGuildId() {
+        return guildId;
+    }
+
+    /**
+     * Gets the ID of the user the mute is registered for.
+     *
+     * @return The user ID the mute is registered for.
+     */
+    public long getUserId() {
+        return userId;
+    }
+
+    /**
+     * Gets the date and time the mute should automatically expire,
+     * or {@code NULL} if the mute is permanent.
+     *
+     * @return The carbon instance for when the mute should end, or {@code NULL}.
+     */
+    @Nullable
+    public Carbon getExpiresAt() {
+        return expiresAt;
+    }
+
+    /**
+     * Gets the future scheduled task for the mute, this task is used
+     * to automatically unmute a user if there is 5 minutes or less
+     * left of their temporary mute.
+     * <p>
+     * If this value is {@code NULL} the automatic mute task haven't
+     * yet been started for the mute container.
+     *
+     * @return The future scheduled task used to auto unmute the container, or {@code NULL}.
+     */
+    @Nullable
+    public ScheduledFuture<?> getSchedule() {
+        return schedule;
+    }
+
+    /**
+     * Sets the future scheduled task that should automatically unmute the container.
+     *
+     * @param schedule The future task used to unmute the container.
+     */
+    public void setSchedule(@Nonnull ScheduledFuture<?> schedule) {
+        this.schedule = schedule;
+    }
+
+    /**
+     * Cancels the future scheduled task used to automatically
+     * unmute the container if one has been started.
+     */
+    public void cancelSchedule() {
+        if (schedule != null) {
+            schedule.cancel(true);
+        }
+    }
+
+    /**
+     * Checks if the registered mute is permanent or temporary.
+     *
+     * @return {@code True} if the mute is permanent, {@code False} otherwise.
+     */
+    public boolean isPermanent() {
+        return getExpiresAt() == null;
+    }
+
+    /**
+     * Compares the current and given container, checking if
+     * they're registered under the same guild and user IDs.
+     *
+     * @param container The container that should be compared.
+     * @return {@code True} if the containers match, {@code False} otherwise.
+     */
+    public boolean isSame(@Nonnull MuteContainer container) {
+        return isSame(container.getGuildId(), container.getUserId());
+    }
+
+    /**
+     * Compares the current container with the given guild and user IDs,
+     * checking if the current container is registered to the same
+     * guild and user IDs given.
+     *
+     * @param guildId The guild ID that should be compared.
+     * @param userId  The user ID that should be compared.
+     * @return {@code True} if the IDs match, {@code False} otherwise.
+     */
+    public boolean isSame(long guildId, long userId) {
+        return getGuildId() == guildId
+            && getUserId() == userId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj instanceof MuteContainer && isSame((MuteContainer) obj);
+    }
+
+    @Override
+    public String toString() {
+        return I18n.format("MuteContainer={guildId={0}, userId={1}, expiresAt={2}}",
+            getGuildId(), getUserId(), getExpiresAt()
+        );
+    }
+}

--- a/src/main/java/com/avairebot/mute/MuteManager.java
+++ b/src/main/java/com/avairebot/mute/MuteManager.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.mute;
+
+import com.avairebot.AvaIre;
+import com.avairebot.Constants;
+import com.avairebot.database.collection.Collection;
+import com.avairebot.database.collection.DataRow;
+import com.avairebot.language.I18n;
+import com.avairebot.modlog.ModlogType;
+import com.avairebot.time.Carbon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class MuteManager {
+
+    private final Logger log = LoggerFactory.getLogger(MuteManager.class);
+    private final HashMap<Long, HashSet<MuteContainer>> mutes = new HashMap<>();
+
+    private final AvaIre avaire;
+
+    /**
+     * Creates the mute manager instance with the given AvaIre
+     * application instance, the mute manager will sync the
+     * mutes entities from the database into memory.
+     *
+     * @param avaire The main AvaIre instance.
+     */
+    public MuteManager(AvaIre avaire) {
+        this.avaire = avaire;
+
+        syncWithDatabase();
+    }
+
+    /**
+     * Registers a mute using the given case ID, guild ID, and user ID,
+     * if a null value is given for the expire date, the mute will be
+     * registered as a permanent mute, however if a valid carbon
+     * instance is given that is set in the future, the mute
+     * will automatically be reversed once the time is up.
+     * <p>
+     * If a mute record already exists for the given guild and user IDs,
+     * the record will be unmuted before the new mute is applied, this
+     * helps ensure that a user can only have one mute per guild.
+     *
+     * @param caseId    The ID of the modlog case that triggered the mute action.
+     * @param guildId   The ID of the guild the mute should be registered to.
+     * @param userId    The ID of the user that was muted.
+     * @param expiresAt The time the mute should be automatically unmuted, or {@code NULL} to make the mute permanent.
+     * @throws SQLException If the mute fails to be registered with the database, or
+     *                      existing mutes for the given guild and user IDs fails
+     *                      to be removed before the new mute is registered.
+     */
+    public void registerMute(String caseId, long guildId, long userId, @Nullable Carbon expiresAt) throws SQLException {
+        if (!mutes.containsKey(guildId)) {
+            mutes.put(guildId, new HashSet<>());
+        }
+
+        if (isMuted(guildId, userId)) {
+            unregisterMute(guildId, userId);
+        }
+
+        avaire.getDatabase().newQueryBuilder(Constants.MUTE_TABLE_NAME)
+            .insert(statement -> {
+                statement.set("guild_id", guildId);
+                statement.set("modlog_id", caseId);
+                statement.set("expires_in", expiresAt);
+            });
+
+        mutes.get(guildId).add(new MuteContainer(guildId, userId, expiresAt));
+    }
+
+    /**
+     * Unregisters a mute matching the given guild ID and user ID.
+     *
+     * @param guildId The ID of the guild the mute should've been registered to.
+     * @param userId  The ID of the user that should be unmuted.
+     * @throws SQLException If the unmute fails to delete the mute record from the database.
+     */
+    public void unregisterMute(long guildId, long userId) throws SQLException {
+        if (!mutes.containsKey(guildId)) {
+            return;
+        }
+
+        final boolean[] removedEntities = {false};
+        synchronized (mutes) {
+            mutes.get(guildId).removeIf(next -> {
+                if (!next.isSame(guildId, userId)) {
+                    return false;
+                }
+
+                if (next.getSchedule() != null) {
+                    next.cancelSchedule();
+                }
+
+                removedEntities[0] = true;
+                return true;
+            });
+        }
+
+        if (removedEntities[0]) {
+            cleanupMutes(guildId, userId);
+        }
+    }
+
+    /**
+     * Checks if there are any mute record that exists
+     * using the given guild and user IDs.
+     *
+     * @param guildId The ID of the guild that should be checked.
+     * @param userId  The ID of the user that should be muted.
+     * @return {@code True} if a user with the given ID is muted on a server
+     * with the given guild ID, {@code False} otherwise.
+     */
+    public boolean isMuted(long guildId, long userId) {
+        if (!mutes.containsKey(guildId)) {
+            return false;
+        }
+
+        for (MuteContainer container : mutes.get(guildId)) {
+            if (container.isSame(guildId, userId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets the total amount of mutes currently stored in memory,
+     * this includes permanent and temporary mutes.
+     *
+     * @return The total amount of mutes stored.
+     */
+    public int getTotalAmountOfMutes() {
+        int totalMutes = 0;
+        for (Map.Entry<Long, HashSet<MuteContainer>> entry : mutes.entrySet()) {
+            totalMutes += entry.getValue().size();
+        }
+        return totalMutes;
+    }
+
+    /**
+     * Gets the map of mutes currently stored, where the key is the guild ID for
+     * the mutes, and the value is a set of mute containers, which holds
+     * the information about each individual mute.
+     *
+     * @return The complete map of mutes currently stored.
+     */
+    public HashMap<Long, HashSet<MuteContainer>> getMutes() {
+        return mutes;
+    }
+
+    private void syncWithDatabase() {
+        log.info("Syncing mutes with the database...");
+
+        String query = I18n.format("SELECT `{1}`.`guild_id`, `{1}`.`target_id`, `{0}`.`expires_in` FROM `{0}` INNER JOIN `{1}` ON `{0}`.`modlog_id` = `{1}`.`modlogCase` WHERE `{0}`.`modlog_id` = `{1}`.`modlogCase` AND `{0}`.`guild_id` = `{1}`.`guild_id`;",
+            Constants.MUTE_TABLE_NAME, Constants.LOG_TABLE_NAME
+        );
+
+        try {
+            int size = getTotalAmountOfMutes();
+            for (DataRow row : avaire.getDatabase().query(query)) {
+                long guildId = row.getLong("guild_id");
+
+                if (!mutes.containsKey(guildId)) {
+                    mutes.put(guildId, new HashSet<>());
+                }
+
+                mutes.get(guildId).add(new MuteContainer(
+                    row.getLong("guild_id"),
+                    row.getLong("target_id"),
+                    row.getTimestamp("expires_in")
+                ));
+            }
+
+            log.info("Syncing complete! {} mutes entries was found that has not expired yet",
+                getTotalAmountOfMutes() - size
+            );
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void cleanupMutes(long guildId, long userId) throws SQLException {
+        Collection collection = avaire.getDatabase().newQueryBuilder(Constants.MUTE_TABLE_NAME)
+            .select(Constants.MUTE_TABLE_NAME + ".modlog_id as id")
+            .innerJoin(
+                Constants.LOG_TABLE_NAME,
+                Constants.MUTE_TABLE_NAME + ".modlog_id",
+                Constants.LOG_TABLE_NAME + ".modlogCase"
+            )
+            .where(Constants.LOG_TABLE_NAME + ".guild_id", guildId)
+            .andWhere(Constants.LOG_TABLE_NAME + ".target_id", userId)
+            .andWhere(Constants.MUTE_TABLE_NAME + ".guild_id", guildId)
+            .andWhere(builder -> builder
+                .where(Constants.LOG_TABLE_NAME + ".type", ModlogType.MUTE.getId())
+                .orWhere(Constants.LOG_TABLE_NAME + ".type", ModlogType.TEMP_MUTE.getId())
+            ).get();
+
+        if (!collection.isEmpty()) {
+            String query = String.format("DELETE FROM `%s` WHERE `guild_id` = ? AND `modlog_id` = ?",
+                Constants.MUTE_TABLE_NAME
+            );
+
+            avaire.getDatabase().queryBatch(query, statement -> {
+                for (DataRow row : collection) {
+                    statement.setLong(1, guildId);
+                    statement.setString(2, row.getString("id"));
+                    statement.addBatch();
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/avairebot/scheduler/jobs/generic/RunEveryMinuteJob.java
+++ b/src/main/java/com/avairebot/scheduler/jobs/generic/RunEveryMinuteJob.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 public class RunEveryMinuteJob extends Job {
 
     private final ChangeGameTask changeGameTask = new ChangeGameTask();
+    private final DrainMuteQueueTask drainMuteQueueTask = new DrainMuteQueueTask();
     private final GarbageCollectorTask garbageCollectorTask = new GarbageCollectorTask();
     private final SyncBlacklistMetricsTask syncBlacklistMetricsTask = new SyncBlacklistMetricsTask();
     private final ResetRespectStatisticsTask resetRespectStatisticsTask = new ResetRespectStatisticsTask();
@@ -47,6 +48,7 @@ public class RunEveryMinuteJob extends Job {
     public void run() {
         handleTask(
             changeGameTask,
+            drainMuteQueueTask,
             garbageCollectorTask,
             syncBlacklistMetricsTask,
             resetRespectStatisticsTask,

--- a/src/main/java/com/avairebot/scheduler/tasks/DrainMuteQueueTask.java
+++ b/src/main/java/com/avairebot/scheduler/tasks/DrainMuteQueueTask.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2019.
+ *
+ * This file is part of AvaIre.
+ *
+ * AvaIre is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * AvaIre is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with AvaIre.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+package com.avairebot.scheduler.tasks;
+
+import com.avairebot.AvaIre;
+import com.avairebot.contracts.scheduler.Task;
+import com.avairebot.database.controllers.GuildController;
+import com.avairebot.database.transformers.GuildTransformer;
+import com.avairebot.language.I18n;
+import com.avairebot.modlog.Modlog;
+import com.avairebot.modlog.ModlogAction;
+import com.avairebot.modlog.ModlogType;
+import com.avairebot.mute.MuteContainer;
+import com.avairebot.scheduler.ScheduleHandler;
+import com.avairebot.time.Carbon;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class DrainMuteQueueTask implements Task {
+
+    private static final Logger log = LoggerFactory.getLogger(DrainMuteQueueTask.class);
+
+    @Override
+    public void handle(AvaIre avaire) {
+        if (avaire.getMuteManger() == null || avaire.getMuteManger().getMutes().isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<Long, HashSet<MuteContainer>> entry : avaire.getMuteManger().getMutes().entrySet()) {
+            for (MuteContainer container : entry.getValue()) {
+                if (container.isPermanent() || container.getSchedule() != null) {
+                    continue;
+                }
+
+                Carbon expires = container.getExpiresAt();
+                //noinspection ConstantConditions
+                if (expires.copy().subMinutes(5).isPast()) {
+                    long differenceInSeconds = expires.diffInSeconds();
+
+                    log.debug("Unmute task started for guildId:{}, userId:{}, time:{}",
+                        container.getGuildId(), container.getUserId(), differenceInSeconds
+                    );
+
+                    container.setSchedule(ScheduleHandler.getScheduler().schedule(
+                        () -> handleAutomaticUnmute(avaire, container),
+                        differenceInSeconds,
+                        TimeUnit.SECONDS
+                    ));
+                }
+            }
+        }
+    }
+
+    private void handleAutomaticUnmute(AvaIre avaire, MuteContainer container) {
+        try {
+            avaire.getMuteManger().unregisterMute(container.getGuildId(), container.getUserId());
+        } catch (SQLException e) {
+            log.error("Failed to unregister mute for guildId:{}, userId:{}",
+                container.getGuildId(), container.getUserId(), e
+            );
+        }
+
+        Guild guild = avaire.getShardManager().getGuildById(container.getGuildId());
+        if (guild == null) {
+            return;
+        }
+
+        Member member = guild.getMemberById(container.getUserId());
+        if (member == null) {
+            return;
+        }
+
+        GuildTransformer transformer = GuildController.fetchGuild(avaire, guild);
+        if (transformer == null) {
+            return;
+        }
+
+        Role muteRole = guild.getRoleById(transformer.getMuteRole());
+        if (muteRole == null) {
+            return;
+        }
+
+        guild.getController().removeSingleRoleFromMember(
+            member, muteRole
+        ).queue(aVoid -> {
+            ModlogAction modlogAction = new ModlogAction(
+                ModlogType.UNMUTE, guild.getSelfMember().getUser(), member.getUser(),
+                I18n.getString(guild, "administration.UnmuteCommand.userAutoUnmutedReason")
+            );
+
+            String caseId = Modlog.log(avaire, guild, transformer, modlogAction);
+            Modlog.notifyUser(member.getUser(), guild, modlogAction, caseId);
+        });
+    }
+}

--- a/src/main/java/com/avairebot/utilities/MentionableUtil.java
+++ b/src/main/java/com/avairebot/utilities/MentionableUtil.java
@@ -248,6 +248,37 @@ public class MentionableUtil {
     }
 
     /**
+     * Gets the first role object matching in the given context and arguments, the
+     * method will try the following to get a role object out the other end.
+     * <ul>
+     * <li>Discord mentions (@Member)</li>
+     * <li>Name mentions (member)</li>
+     * <li>Role ID (333649597094166539)</li>
+     * </ul>
+     * <p>
+     * If none of the checks finds a valid role object, <code>null</code> will be returned instead.
+     *
+     * @param message The command message.
+     * @param args    The arguments parsed to the command.
+     * @return Possibly-null, or the first role matching the given arguments.
+     */
+    public static Role getRole(@Nonnull Message message, @Nonnull String[] args) {
+        if (args.length == 0) {
+            return RoleUtil.getRoleFromMentionsOrName(message, "");
+        }
+
+        String potentialRoleId = args[0].trim();
+        if (NumberUtil.isNumeric(potentialRoleId)) {
+            Role role = message.getGuild().getRoleById(potentialRoleId);
+            if (role != null) {
+                return role;
+            }
+        }
+
+        return RoleUtil.getRoleFromMentionsOrName(message, String.join(" ", args));
+    }
+
+    /**
      * The channel priority type, used for specifying what type of channel
      * should be prioritised when looking for a channel by name.
      */

--- a/src/main/java/com/avairebot/utilities/RoleUtil.java
+++ b/src/main/java/com/avairebot/utilities/RoleUtil.java
@@ -46,6 +46,10 @@ public class RoleUtil {
             return message.getMentionedRoles().get(0);
         }
 
+        if (roleName.length() == 0) {
+            return null;
+        }
+
         List<Role> roles = message.getGuild().getRolesByName(roleName, true);
         return roles.isEmpty() ? null : roles.get(0);
     }

--- a/src/main/resources/langs/da_DK.yml
+++ b/src/main/resources/langs/da_DK.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Kunne ikke redigere modlog besked: {0}"
         failedToFindMessage: "Kunne ikke finde meddelelsen for det givne modlog-case ID, er den blevet slettet?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Ugyldig kanal eller status type givet!"
         notValidChannel: "`{0}` er ikke en gyldig tekst kanal!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Kunne ikke unbanne :target på grund af det opstod en fejl: :error"
         noUserIsBanned: "Der er ingen brugerer med ID'et `:id` der er bannet fra serveren i øjeblikket."
         invalidUserIdGiven: "Ugyldig `bruger id` blev givet,` bruger id` skal være en numerisk streng på 18 eller flere tal lang."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "Du skal nævne den bruger du ønsker at kicke."

--- a/src/main/resources/langs/de_DE.yml
+++ b/src/main/resources/langs/de_DE.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Editieren der Modlog-Nachricht fehlgeschlagen: {0}"
         failedToFindMessage: "Die Nachricht für den angegebenen Modlog-Fall konnte nicht aufgefunden werden. Wurde dieser entfernt?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Ungültiger Channel oder Status-Typ angegeben."
         notValidChannel: "`{0}` ist kein gültiger Textchannel."
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Beim Versuch :target zu Entbannen ist ein Fehler aufgetreten. Fehlermeldung: :error"
         noUserIsBanned: "Kein User mit der ID `:id` ist auf dem Server verbannt."
         invalidUserIdGiven: "Ungültige `User-ID` angegeben. Die `User-ID` muss eine 18-stellige oder längere Nummer sein."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "Du musst den User angeben, den du aus dem Voice-Channel kicken möchtest."

--- a/src/main/resources/langs/en_US.yml
+++ b/src/main/resources/langs/en_US.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user that you want to kick."

--- a/src/main/resources/langs/es_ES.yml
+++ b/src/main/resources/langs/es_ES.yml
@@ -242,6 +242,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -312,6 +332,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user you want to kick."

--- a/src/main/resources/langs/fr_FR.yml
+++ b/src/main/resources/langs/fr_FR.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user you want to kick."

--- a/src/main/resources/langs/hu_HU.yml
+++ b/src/main/resources/langs/hu_HU.yml
@@ -249,6 +249,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -319,6 +339,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user you want to kick."

--- a/src/main/resources/langs/it_IT.yml
+++ b/src/main/resources/langs/it_IT.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Impossibile modificare il messaggio modlog: {0}"
         failedToFindMessage: "Impossibile trovare il messaggio per il caso del modlog specificato, è stato eliminato?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Canale o valore NSFW non valido!"
         notValidChannel: "`{0}` non è un canale di testo valido!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Impossibile sbannare :target a causa di un errore: :error"
         noUserIsBanned: "Nessun utente con l'ID `:id` è attualmente bannato dal server."
         invalidUserIdGiven: "Hai inserito un `id utente` non valido, l'`id utente` deve essere una stringa numerica di 18 o più numeri."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "Devi menzionare l'utente che vuoi kickare."

--- a/src/main/resources/langs/nl_NL.yml
+++ b/src/main/resources/langs/nl_NL.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Gefaald met het veranderen van het modlog bericht: {0}"
         failedToFindMessage: "Kon het bericht voor de modlog case niet vinden, is het verwijderd?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Ongeldig kanaal of status type gegeven!"
         notValidChannel: "`{0}` is geen geldig tekst kanaal!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Gefaald met unbannen van :target door een error: :error"
         noUserIsBanned: "Geen gebruiker met het ID `:id` is momenteel gebanned van de server."
         invalidUserIdGiven: "Ongeldige `user id` is gegeven, de `user id` moet een nummer van 18 karakters of langer zijn."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "Je moet een gebruiker noemen die je wil kicken."

--- a/src/main/resources/langs/no_NB.yml
+++ b/src/main/resources/langs/no_NB.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user you want to kick."

--- a/src/main/resources/langs/ru_RU.yml
+++ b/src/main/resources/langs/ru_RU.yml
@@ -241,6 +241,26 @@ administration:
         failedToEdit: "Failed to edit modlog message: {0}"
         failedToFindMessage: "Couldn't find the message for the given modlog case, was it deleted?"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "Invalid channel or status type given!"
         notValidChannel: "`{0}` is not a valid text channel!"
@@ -311,6 +331,15 @@ administration:
         failedToUnban: "Failed to unban :target due to an error, message: :error"
         noUserIsBanned: "No user with an ID of `:id` is currently banned from the server."
         invalidUserIdGiven: "Invalid `user id` was given, the `user id` must be a numeric string of 18 or more numbers long."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "You must mention the user you want to kick."

--- a/src/main/resources/langs/zh_SI.yml
+++ b/src/main/resources/langs/zh_SI.yml
@@ -240,6 +240,26 @@ administration:
         failedToEdit: "无法编辑modlog消息: {0}"
         failedToFindMessage: "找不到给定modlog案例的消息，是否已删除？"
 
+    MuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically assign the role to other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to mute to use this command."
+        invalidTimeGiven: "Invalid time given, the time must be at least one minute or more."
+        userHasBeenMuted: ":target has been muted :time!"
+        time:
+            permanently: "permanently"
+            forFormat: "for {0}"
+
+    MuteRoleCommand:
+        roleDoesntExists: "Invalid role given, the `{0}` role doesn't exists."
+        rolePositionedHigher: "The {0} role is positioned higher than any role I have, so I can assign the role to anyone."
+        cantCreateRoleDueToPermissions: "I can't create the muted role because I don't have the \"Manage Roles\" permissions for the server."
+        noMuteRoleSet: "There are currently no mute role set for the server, you can set the role you wanna use as the mute role using `:command set <role>`, or you can make the bot create a new muted role using `:command create-role`."
+        usingRoleMessage: "The server is using the :role role for mutes."
+        roleHasBeenRemoved: "The muted role has been removed, the mute feature is now disabled until another muted role is assigned."
+        nowUsingRole: "The <@&:roleId> role will now be used for muting users."
+
     NSFWCommand:
         invalidChannelOrStatus: "给定的通道或状态类型无效!"
         notValidChannel: "`{0}` 不是有效的文本通道!"
@@ -310,6 +330,15 @@ administration:
         failedToUnban: "未能取消禁止 :target 由于错误, message: :error"
         noUserIsBanned: "没有ID为 `:id` 当前在服务器上被禁止。."
         invalidUserIdGiven: " `user id` 无效, 这个 `user id` 必须是长度为18个或更多数字的数字字符串."
+
+    UnmuteCommand:
+        requiresModlogToBeSet: "This command requires a modlog channel to be set, a modlog channel can be set using the `{0}modlog` command."
+        requireMuteRoleToBeSet: "No mute role have been setup for the server, you can setup a mute role using the `{0}muterole` command."
+        muteRoleIsPositionedHigher: "The {0} role used for mutes are positioned higher in the role hierarchy than any roles I have, so I can't automatically remove the role from other users, please fix this or use another role for mutes."
+        invalidUserMentioned: "Invalid user mentioned, you must mention a user on the server you want to unmute to use this command."
+        userDoesntHaveMuteRole: "{0} doesn't appear to have the mute role, they may already have been unmuted!"
+        userHasBeenUnmuted: ":target has been unmuted!"
+        userAutoUnmutedReason: "*Automatic unmute after the set time has elapsed*"
 
     VoiceKickCommand:
         mustMentionUser: "你必须提到你想踢的用户。."


### PR DESCRIPTION
* Create mute database schema

* Create mute modlog type

* Create mute role command

* Mute Command and modlog case messages

* Add support for setting existing roles as the muted role

* Create unmute command

* Add guild id column to mutes to make them unique per server

* Fix SQLite database types adding the mute role column correctly

Thanks to Chara#6274 on Discord for pointing this out.

* Add automatic cleanup and mute handler to track and sync mutes

* Change the vote handler to a manager type

* Add check to automatically re-add the muted role on server join

Any user who is stilled muted on a server and then joins that server will have the muted role reapplied to them.

* Add a minimum mute time of 1 minute

* Create a drain mute queue task to unmute temporary mutes

* Add some debugging and error log outputs to the mute queue task

* Add error logging output to mute commands in event of SQL errors

* Add command relationships

* Write descriptions for the commands

* Remove unnecessary space

* Refactor code and add documentation to public API methods

* Change permission requirement for mute commands to Manage Messages

* Create automatic role cleanup if a mute role is deleted

* Remove existing role check from the mute command

* Move all messages out to the language files

* Bump version