### PR TITLE
Add proxy API and website build instructions for Heroku (#113)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: java -jar AvaIre.jar --no-colors -env
+web: vendor/bin/heroku-php-apache2 -C avairebotapache2.conf public/ & java -jar AvaIre.jar --no-colors -env
 worker: java -jar AvaIre.jar --no-colors -env

--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
     "website": "https://avairebot.com/",
     "repository": "https://github.com/avaire/avaire",
     "logo": "https://imgur.com/H8RCD5F.png",
-    "success_url": "/stats",
+    "success_url": "/",
     "addons": [
         {
             "plan": "jawsdb:kitefin"
@@ -131,6 +131,11 @@
             "required": false,
             "value": ""
         },
+		"AVA_WEB_SERVLET_PORT": {
+			"description": "overrides the PORT env variable. Leave as is inorder to access the API with proxy on /avairebotapi/.",
+			"required": false,
+			"value": "8080"
+		},
         "AVA_WEB_SERVLET_METRICS": {
             "description": "Ava uses Prometheus metrics for tracking a long list of different things within the application during runtime, the metrics are then displayed using Grafana to users on a web-dashboard using graphs.",
             "required": false,
@@ -254,13 +259,22 @@
     },
     "buildpacks": [
         {
-            "url": "https://github.com/weibeld/heroku-buildpack-run"
+            "url": "https://github.com/650health/heroku-buildpack-run"
         },
         {
             "url": "heroku/gradle"
         },
         {
-            "url": "https://github.com/650health/heroku-buildpack-run"
+            "url": "https://github.com/weibeld/heroku-buildpack-run"
+        },
+        {
+            "url": "heroku/php"
+        },	
+        {
+            "url": "https://github.com/luo83651896/heroku-buildpack-run"
+        },
+        {
+            "url": "heroku/nodejs"
         }
     ]
 }

--- a/avairebotapache2.conf
+++ b/avairebotapache2.conf
@@ -1,0 +1,7 @@
+# Gives permission to the user to display what is in these files in a given folder
+DirectoryIndex index.html index.cgi index.pl index.php index.xhtml
+
+# Proxy when accessing /avairebotapi/ to display the content from the internal AvaIrebot
+# /avairebotapi/ access the port defined in: AVA_WEB_SERVLET_PORT.
+ProxyPass "/avairebotapi/" "http://localhost:${AVA_WEB_SERVLET_PORT}/" connectiontimeout=5 timeout=30 keepalive=on
+ProxyPassReverse "/avairebotapi/" "http://localhost:${AVA_WEB_SERVLET_PORT}/"

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,5 +1,45 @@
-# This is buildpack-run.sh
-# Trick to clone AvaIre's git into a seperate folder, copying .git to the top directory. Followed by putting the config.yml on the right place.
-rm -rf .git && git clone https://github.com/avaire/avaire.git && cp -r avaire/.git . && cp src/main/resources/config.yml . && cp src/main/resources/constants.yml . && rm -rf avaire/ && echo script worked.
-# Cleaning any build artifacts, done before and after the gradle proces.
-rm -rf build/ && echo cleaned out build artifacts.
+# If AvaIre.jar is compiled
+if [ -d ".git" ]; then
+  # Second step
+  echo ==========================
+  echo ====== Second Part =======
+  echo ==========================
+  echo Moving some files we want to keep after getting the website. We also generate the commandMap.json.
+  echo After getting the website files in the right directory, we move the files back in the right directory with the website files.
+  # Generating the commandMap.json
+  java -jar AvaIre.jar --generate-json-file
+  # Moving the config files needed to run AvaIre.jar and the Apache2 webserver outside the app/ folder
+  mv src/main/resources/config.yml ../config.yml
+  mv src/main/resources/constants.yml ../constants.yml
+  mv AvaIre.jar ../AvaIre.jar
+  mv avairebotapache2.conf ../avairebotapache2.conf
+  mv commandMap.json ../commandMap.json
+  mv Procfile ../Procfile
+  # Entire /app/ directory is cleared out, to prepare to retrieve the webfiles
+  rm -r * & rm -r .git/
+  # The website is being cloned and moven out of it's folder
+  git clone https://github.com/avaire/website # Example: avaire/website
+  mv website/* .
+  rm -r website/
+  # Moving the config files needed to run everything back into the original directory
+  mv ../config.yml .
+  mv ../constants.yml .
+  mv ../AvaIre.jar .
+  mv ../avairebotapache2.conf .
+  mv ../commandMap.json storage/commandMap.json
+  mv ../Procfile . # The Procfile will now override the Procfile from the website repo
+# If AvaIre.jar isn't compiled
+else
+  # First step
+  echo ==========================
+  echo ====== First Part ========
+  echo ==========================
+  echo First part, set the .git folder.
+  git clone https://github.com/avaire/avaire # Example: avaire/avaire
+  mv avaire/.git .
+  # Doing this temporarly b/c of system env variables missing
+  mv .env.example .env
+  wget -O .env https://pastebin.com/raw/7WwskUtj
+fi
+echo This is the end of the script
+# The third time the build-run.sh is ran, it won't be this script but the one over at the website repo!


### PR DESCRIPTION
* Create avairebotapache2.conf

Configuration to tell Apache2 to proxy

* added new Procfile and env variables

* added new Procfile and env variables

* added new Procfile and env variables

* added new Procfile and env variables

* added new Procfile and env variables

* added new Procfile and env variables

* removed env variables

* update AvaIre with fuse website component for Heroku

* add needed buildpacks

* Empty env is beter then someone else's